### PR TITLE
SQL schema update for PostgreSQL 15

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,6 @@
 0.8.5 (beta 1)
+	- Removed 'WITH OIDS' from SQL table creation; not supported since 
+	  version 12. [svamberg]
 	- Fixed zone expiration. Defined value was not honored while generating
 	  configurations. While on the matter, added also zone expiration to
 	  show in zone listing. Pink denotes already expired zone, pale yellow

--- a/README
+++ b/README
@@ -50,6 +50,8 @@ TESTED PLATFORMS
 
 
 INSTALLATION 
+  
+  This instalation was tested on Debian 13.1.
 
   See User Guide for complete installation instruction. This section
   is only a quick overview of the installation process:
@@ -62,7 +64,13 @@ INSTALLATION
 
   2) Create database for Sauron to use in PostgreSQL
      	(use createdb command to create the database, see PostgreSQL
-	 documentation for more help)
+	 documentation for more help), example:
+        su postgres
+        createdb sauron;
+        psql
+        psql> CREATE USER sauron WITH PASSWORD '<random_password>';
+        psql> ALTER DATABASE sauron OWNER TO sauron;
+        psql> exit
 
   3) Edit configuration files: config and config-browser
 	(these are usually in /usr/local/etc/sauron or /etc/sauron)

--- a/sql/a_entries.sql
+++ b/sql/a_entries.sql
@@ -15,8 +15,7 @@ CREATE TABLE a_entries (
       reverse	   BOOL DEFAULT true, /* generate reverse (PTR) record flag */
       forward      BOOL DEFAULT true, /* generate (A) record flag */
       comment	   CHAR(20)
-)
-WITH OIDS;
+);
 
 CREATE INDEX a_entries_ip_index ON a_entries (ip);
 CREATE INDEX a_entries_host_index ON a_entries (host);

--- a/sql/acls.sql
+++ b/sql/acls.sql
@@ -16,6 +16,5 @@ CREATE TABLE acls (
        comment	    TEXT,
 
        CONSTRAINT   acls_key UNIQUE(name,server)
-) INHERITS(common_fields)
-WITH OIDS;
+) INHERITS(common_fields);
 

--- a/sql/arec_entries.sql
+++ b/sql/arec_entries.sql
@@ -11,7 +11,7 @@ CREATE TABLE arec_entries (
 					-->hosts.id */
       arec         INT4 NOT NULL  /* ptr to aliased host id 
 					-->hosts.id */
-) WITH OIDS;
+);
 
 CREATE INDEX arec_entries_host_index ON arec_entries (host);
 

--- a/sql/cidr_entries.sql
+++ b/sql/cidr_entries.sql
@@ -44,7 +44,7 @@ CREATE TABLE cidr_entries (
 					1 = NOT */
 	port	    INT,            /* port value, used by: forwarders */      
 	comment     TEXT
-) WITH OIDS;
+);
 
 CREATE INDEX cidr_entries_ref_index ON cidr_entries (type,ref);
 CREATE INDEX cidr_entries_ip_index ON cidr_entries (ip);

--- a/sql/common.sql
+++ b/sql/common.sql
@@ -12,7 +12,7 @@ CREATE TABLE common_fields (
        mdate	   INT4, /* modification date */
        muser	   CHAR(8) DEFAULT 'unknown', /* last changed by this user */
        expiration  INT4  /* expiration date */
-) WITH OIDS;
+);
 
 
 /** global settings table **/
@@ -23,4 +23,4 @@ CREATE TABLE settings (
 	ivalue  INT4, /* interger value of setting */
 	
 	CONSTRAINT global_key PRIMARY KEY (setting)
-) WITH OIDS;
+);

--- a/sql/dbconvert_1.0to1.1
+++ b/sql/dbconvert_1.0to1.1
@@ -62,7 +62,7 @@ CREATE TABLE vmps (
        comment	   TEXT, /* comments */
 
        CONSTRAINT  vmps_key PRIMARY KEY (name,server)
-) INHERITS(common_fields) WITH OIDS;
+) INHERITS(common_fields);
 
 
 

--- a/sql/dbconvert_1.1to1.2
+++ b/sql/dbconvert_1.1to1.2
@@ -27,7 +27,7 @@ CREATE TABLE group_entries (
 					-->hostss.id */
       grp          INT4 NOT NULL  /* ptr to group (this host) belogs to
 					-->groups.id */
-) WITH OIDS;
+);
 
 
 

--- a/sql/dbconvert_1.2to1.3
+++ b/sql/dbconvert_1.2to1.3
@@ -74,7 +74,7 @@ CREATE TABLE keys (
 	comment     TEXT,
 
 	CONSTRAINT  keyname_key UNIQUE(name,ref,type)
-) INHERITS(common_fields) WITH OIDS;
+) INHERITS(common_fields);
 
 
 /* acls table creation */
@@ -89,7 +89,7 @@ CREATE TABLE acls (
        comment	    TEXT,
 
        CONSTRAINT   acls_key UNIQUE(name,server)
-) INHERITS(common_fields) WITH OIDS;
+) INHERITS(common_fields);
 
 INSERT INTO acls (server,name) VALUES(-1,'any');
 INSERT INTO acls (server,name) VALUES(-1,'none');
@@ -114,7 +114,7 @@ CREATE TABLE leases (
       uid	   TEXT, /* dhcp uid */
       hostname     TEXT, /* dhcp hostname */
       info	   TEXT  /* extra info */
-) WITH OIDS;
+);
 
 CREATE INDEX leases_mac_index ON leases (mac);
 CREATE INDEX leases_ip_index ON leases (ip);

--- a/sql/dhcp_entries.sql
+++ b/sql/dhcp_entries.sql
@@ -22,7 +22,7 @@ CREATE TABLE dhcp_entries (
 					-->groups.id */
 	dhcp	    TEXT, /* DHCP entry value (without trailing ';') */
         comment     TEXT
-) WITH OIDS;
+);
 
 CREATE INDEX dhcp_entries_ref_index ON dhcp_entries (type,ref);
 

--- a/sql/ether_info.sql
+++ b/sql/ether_info.sql
@@ -9,5 +9,5 @@ CREATE TABLE ether_info (
        	ea		CHAR(6) PRIMARY KEY, /* manufacturer code 
 					      (6 bytes in hex) */
        	info		TEXT /* manufacturer name & info */
-) WITH OIDS;
+);
 

--- a/sql/group_entries.sql
+++ b/sql/group_entries.sql
@@ -12,7 +12,7 @@ CREATE TABLE group_entries (
 					-->hostss.id */
       grp          INT4 NOT NULL  /* ptr to group (this host) belogs to
 					-->groups.id */
-) WITH OIDS;
+);
 
 CREATE INDEX group_entries_host_index ON group_entries (host);
 

--- a/sql/groups.sql
+++ b/sql/groups.sql
@@ -24,5 +24,5 @@ CREATE TABLE groups (
        comment	    TEXT,
 
        CONSTRAINT   groups_key UNIQUE(name,server)
-) INHERITS(common_fields) WITH OIDS;
+) INHERITS(common_fields);
 

--- a/sql/hinfo_templates.sql
+++ b/sql/hinfo_templates.sql
@@ -14,6 +14,6 @@ CREATE TABLE hinfo_templates (
 					1=software */
 	pri     INT4 DEFAULT 100 /* priority (defines the order in which
   			    entries are displayed in user interfaces) */
-) INHERITS(common_fields) WITH OIDS;
+) INHERITS(common_fields);
 
 

--- a/sql/history.sql
+++ b/sql/history.sql
@@ -21,7 +21,7 @@ CREATE TABLE history (
 	ref		INT,      /* optional reference */
 	action		CHAR(25), /* operation performed */
 	info		TEXT      /* extra info */
-) WITH OIDS;
+);
 
 CREATE INDEX history_sid_index ON history(sid);
 CREATE INDEX history_uid_index ON history(uid);

--- a/sql/hosts.sql
+++ b/sql/hosts.sql
@@ -79,6 +79,6 @@ CREATE TABLE hosts (
        CONSTRAINT  hostname_key UNIQUE (domain,zone),
        CONSTRAINT  ether_key UNIQUE(ether,zone),
        CONSTRAINT  asset_key UNIQUE(asset_id,zone)
-) INHERITS(common_fields) WITH OIDS;
+) INHERITS(common_fields);
 
 CREATE UNIQUE INDEX duid_iaid_key ON hosts USING btree (zone, duid, (COALESCE(iaid, (0)::bigint)));

--- a/sql/keys.sql
+++ b/sql/keys.sql
@@ -50,4 +50,4 @@ CREATE TABLE keys (
 	comment     TEXT,
 
 	CONSTRAINT  keyname_key UNIQUE(name,ref,type)
-) INHERITS(common_fields) WITH OIDS;
+) INHERITS(common_fields);

--- a/sql/lastlog.sql
+++ b/sql/lastlog.sql
@@ -19,6 +19,6 @@ CREATE TABLE lastlog (
 	ldate		INT DEFAULT -1, /* logout date */
 	ip		INET,	        /* remote IP */
 	host		TEXT		/* remote host */
-) WITH OIDS;
+);
 
 

--- a/sql/leases.sql
+++ b/sql/leases.sql
@@ -20,7 +20,7 @@ CREATE TABLE leases (
       hostname     TEXT, /* dhcp hostname */
       info	   TEXT,  /* extra info */
       duid     character varying(40)
-) WITH OIDS;
+);
 
 CREATE INDEX leases_mac_index ON leases (mac);
 CREATE INDEX leases_ip_index ON leases (ip);

--- a/sql/mx_entries.sql
+++ b/sql/mx_entries.sql
@@ -18,7 +18,7 @@ CREATE TABLE mx_entries (
         pri	    INT4 NOT NULL CHECK (pri >= 0), /* MX priority */
 	mx	    TEXT, /* MX domain (FQDN) */
         comment     TEXT
-) WITH OIDS;
+);
 
 CREATE INDEX mx_entries_ref_index ON mx_entries (type,ref);
 

--- a/sql/mx_templates.sql
+++ b/sql/mx_templates.sql
@@ -13,5 +13,5 @@ CREATE TABLE mx_templates (
         alevel	        INT4 DEFAULT 0, /* required authorization level */
 	name		TEXT, /* template name */
 	comment		TEXT 
-) INHERITS(common_fields) WITH OIDS;
+) INHERITS(common_fields);
 

--- a/sql/nets.sql
+++ b/sql/nets.sql
@@ -32,6 +32,6 @@ CREATE TABLE nets (
        comment	   TEXT, /* comment */
 
        CONSTRAINT  nets_key UNIQUE (net,server)
-) INHERITS(common_fields) WITH OIDS;
+) INHERITS(common_fields);
 
 

--- a/sql/news.sql
+++ b/sql/news.sql
@@ -11,6 +11,6 @@ CREATE TABLE news (
 	server		INT DEFAULT -1, /* ptr to server or -1 for global
 					   news messages */
        	info		TEXT NOT NULL /* news/motd message */
-) INHERITS(common_fields) WITH OIDS;
+) INHERITS(common_fields);
 
 

--- a/sql/ns_entries.sql
+++ b/sql/ns_entries.sql
@@ -15,7 +15,7 @@ CREATE TABLE ns_entries (
 					-->hosts.id */
 	ns	    TEXT, /* value of NS record (FQDN) */
         comment     TEXT
-) WITH OIDS;
+);
 
 CREATE INDEX ns_entries_ref_index ON ns_entries (type,ref);
 

--- a/sql/printer_classes.sql
+++ b/sql/printer_classes.sql
@@ -11,5 +11,5 @@ CREATE TABLE printer_classes (
        name	    TEXT UNIQUE NOT NULL CHECK(name <> ''), /* class name */
 
        comment	    TEXT 
-) INHERITS(common_fields) WITH OIDS;
+) INHERITS(common_fields);
 

--- a/sql/printer_entries.sql
+++ b/sql/printer_entries.sql
@@ -17,6 +17,6 @@ CREATE TABLE printer_entries (
 					-->printer_classes.id */
 	printer	    TEXT, /* printcap entry */
         comment     TEXT
-) WITH OIDS;
+);
 
 

--- a/sql/root_servers.sql
+++ b/sql/root_servers.sql
@@ -14,4 +14,4 @@ CREATE TABLE root_servers (
 	domain		TEXT NOT NULL,  /* domainname */
 	type		TEXT NOT NULL,  /* A,NS,... */
 	value		TEXT NOT NULL   /* value */
-) WITH OIDS;
+);

--- a/sql/servers.sql
+++ b/sql/servers.sql
@@ -111,6 +111,6 @@ CREATE TABLE servers (
 	comment		TEXT,
 	
 	CONSTRAINT	servers_name_key UNIQUE(name)
-) INHERITS(common_fields) WITH OIDS;
+) INHERITS(common_fields);
 
 

--- a/sql/srv_entries.sql
+++ b/sql/srv_entries.sql
@@ -16,7 +16,7 @@ CREATE TABLE srv_entries (
 	port        INT4 NOT NULL CHECK (port >= 0), /* port */
 	target	    TEXT NOT NULL DEFAULT '.', /* target */
         comment     TEXT /* comment */
-) WITH OIDS;
+);
 
 CREATE INDEX srv_entries_ref_index ON srv_entries (type,ref);
 

--- a/sql/txt_entries.sql
+++ b/sql/txt_entries.sql
@@ -20,7 +20,7 @@ CREATE TABLE txt_entries (
 					-->servers.id */
 	txt	    TEXT,           /* value of TXT record */
         comment     TEXT            /* comments */
-) WITH OIDS;
+);
 
 CREATE INDEX txt_entries_ref_index ON txt_entries (type,ref);
 

--- a/sql/user_groups.sql
+++ b/sql/user_groups.sql
@@ -11,6 +11,6 @@ CREATE TABLE user_groups (
        comment	    TEXT,                              /* comments */
 
        CONSTRAINT   user_groups_name_key UNIQUE(name)
-) WITH OIDS;
+);
 
 

--- a/sql/user_rights.sql
+++ b/sql/user_rights.sql
@@ -32,6 +32,6 @@ CREATE TABLE user_rights (
 				101=asset management flags  */
 	rref	INT NOT NULL, /* ptr to table specified by type field */
 	rule	CHAR(80) /* R,RW,RWS or regexp */
-) WITH OIDS;
+);
 
 CREATE INDEX user_rights_ref_index ON user_rights (type,ref);

--- a/sql/users.sql
+++ b/sql/users.sql
@@ -27,5 +27,5 @@ CREATE TABLE users (
 	comment		TEXT,
 
 	CONSTRAINT	username_key UNIQUE(username)
-) INHERITS(common_fields) WITH OIDS;
+) INHERITS(common_fields);
 

--- a/sql/utmp.sql
+++ b/sql/utmp.sql
@@ -26,5 +26,5 @@ CREATE TABLE utmp (
 	searchopts	TEXT, /* current search options */
 	searchdomain	TEXT, /* current search domain */
 	searchpattern	TEXT  /* current search pattern */
-) WITH OIDS;
+);
 

--- a/sql/vlans.sql
+++ b/sql/vlans.sql
@@ -18,6 +18,6 @@ CREATE TABLE vlans (
        comment	   TEXT,  /* comments */
 
        CONSTRAINT  vlans_key UNIQUE (name,server)
-) INHERITS(common_fields) WITH OIDS;
+) INHERITS(common_fields);
 
 

--- a/sql/vmps.sql
+++ b/sql/vmps.sql
@@ -22,6 +22,6 @@ CREATE TABLE vmps (
        comment	   TEXT, /* comments */
 
        CONSTRAINT  vmps_key UNIQUE (name,server)
-) INHERITS(common_fields) WITH OIDS;
+) INHERITS(common_fields);
 
 

--- a/sql/wks_entries.sql
+++ b/sql/wks_entries.sql
@@ -16,7 +16,7 @@ CREATE TABLE wks_entries (
 	proto	    CHAR(10), /* protocol (tcp,udp) */
 	services    TEXT, /* services (ftp,telnet,smtp,http,...) */
         comment     TEXT
-) WITH OIDS;
+);
 
 CREATE INDEX wks_entries_ref_index ON wks_entries (type,ref);
 

--- a/sql/wks_templates.sql
+++ b/sql/wks_templates.sql
@@ -13,5 +13,5 @@ CREATE TABLE wks_templates (
         alevel	        INT4 DEFAULT 0, /* required authorization level */
 	name		TEXT, /* template name */
 	comment		TEXT
-) INHERITS(common_fields) WITH OIDS;
+) INHERITS(common_fields);
 

--- a/sql/zones.sql
+++ b/sql/zones.sql
@@ -62,5 +62,5 @@ CREATE TABLE zones (
        transfer_source_v6 INET,  /* transfer-source IPv6 (optional) */
 
        CONSTRAINT  zones_key UNIQUE (name,server)
-) INHERITS(common_fields) WITH OIDS;
+) INHERITS(common_fields);
 


### PR DESCRIPTION
Removed 'WITH OIDS' from SQL table creation; not supported since version 12.

Added example of creating a database and user in SQL.