### PR TITLE
Fix charset by locale settings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 0.9.0 (beta)
-
+	- Added Sauron::SetupIO module for correct encoding settings,
+	  sets encoding transport layers according to system settings
+	  (locale for STDIN, STDOUT, STDERR) using Encode::Locale [svamberg]
  - Increased maximum login length to 321 characters to allow storage 
 	  of eduPersonUniqueId according to RFC4512. [svamberg]
 	- Removed 'WITH OIDS' from SQL table creation; not supported since 

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,14 +2,14 @@
 	- Added Sauron::SetupIO module for correct encoding settings,
 	  sets encoding transport layers according to system settings
 	  (locale for STDIN, STDOUT, STDERR) using Encode::Locale [svamberg]
- - Increased maximum login length to 321 characters to allow storage 
+	- Increased maximum login length to 321 characters to allow storage 
 	  of eduPersonUniqueId according to RFC4512. [svamberg]
 	- Removed 'WITH OIDS' from SQL table creation; not supported since 
 	  version 12. [svamberg]
 
 0.8.5
 
-- Fixed zone expiration. Defined value was not honored while generating
+	- Fixed zone expiration. Defined value was not honored while generating
 	  configurations. While on the matter, added also zone expiration to
 	  show in zone listing. Pink denotes already expired zone, pale yellow
 	  warns upcoming expiration from SAURON_REMOVE_EXPIRED_DELAY config

--- a/Makefile.in
+++ b/Makefile.in
@@ -98,7 +98,7 @@ PROGS = sauron addgroup adduser deluser delgroup modhosts \
 
 MODULES = Sauron/Util.pm Sauron/BackEnd.pm Sauron/CGIutil.pm \
 	  Sauron/UtilZone.pm Sauron/Sauron.pm Sauron/UtilDhcp.pm \
-	  Sauron/DB-Pg.pm Sauron/DB-DBI.pm
+	  Sauron/DB-Pg.pm Sauron/DB-DBI.pm Sauron/SetupIO.pm
 
 CGIMODULES = Utils.pm Servers.pm Groups.pm Templates.pm Nets.pm \
 	     Login.pm Zones.pm Hosts.pm ACLs.pm

--- a/README.upgrade
+++ b/README.upgrade
@@ -11,6 +11,8 @@ Sauron version		database version
 0.7.1			1.2
 0.7.2			1.3
 0.7.3			1.4
+0.8.5			1.7
+0.9.0			1.8
 
 
 GENERAL UPGRADE PROCEDURE

--- a/Sauron/BackEnd.pm
+++ b/Sauron/BackEnd.pm
@@ -10,6 +10,7 @@ require Exporter;
 use NetAddr::IP; # For IPv6;
 use Sauron::DB;
 use Sauron::Util;
+use Sauron::SetupIO;
 use Sys::Syslog qw(:DEFAULT setlogsock);
 Sys::Syslog::setlogsock('unix');
 use Net::IP qw (:PROC);
@@ -178,7 +179,7 @@ sub write2log
   my $filename  = File::Basename::basename($0);
 
   Sys::Syslog::openlog($filename, "cons,pid", "debug");
-  Sys::Syslog::syslog("info", "$msg");
+  Sys::Syslog::syslog("info", encode_str("$msg"));
   Sys::Syslog::closelog();
 } # End of write2log
 

--- a/Sauron/BackEnd.pm
+++ b/Sauron/BackEnd.pm
@@ -197,7 +197,7 @@ sub fix_bools($$) {
 }
 
 sub sauron_db_version() {
-  return "1.7"; # required db format version for this backend
+  return "1.8"; # required db format version for this backend
 }
 
 sub set_muser($) {

--- a/Sauron/CGI/Hosts.pm
+++ b/Sauron/CGI/Hosts.pm
@@ -14,6 +14,7 @@ use Sauron::BackEnd;
 use Sauron::Util;
 use Sauron::Sauron;
 use Sauron::CGI::Utils;
+use Sauron::SetupIO;
 use Sys::Syslog qw(:DEFAULT setlogsock);
 Sys::Syslog::setlogsock('unix');
 use Net::IP qw(:PROC);
@@ -33,7 +34,7 @@ sub write2log{
   my $filename  = File::Basename::basename($0);
 
   Sys::Syslog::openlog($filename, "cons,pid", "debug");
-  Sys::Syslog::syslog("info", "$msg");
+  Sys::Syslog::syslog("info", encode_str("$msg"));
   Sys::Syslog::closelog();
 } # End of write2log
 
@@ -348,7 +349,7 @@ my %new_host_form = (
   {ftype=>2, tag=>'srv_l', name=>'SRV entries', fields=>5,len=>[5,5,5,30,20],
 
 #  maxlen=>[5,5,5,400,10], dot=>1,
-
+/
 # Dot (.) allowed to superuser. 2020-08-10 TVu
    maxlen=>[5,5,5,400,80], dot=>check_perms('superuser','',1) ? 0 : 1,
 

--- a/Sauron/CGI/Nets.pm
+++ b/Sauron/CGI/Nets.pm
@@ -13,6 +13,7 @@ use Sauron::CGIutil;
 use Sauron::BackEnd;
 use Sauron::Sauron;
 use Sauron::CGI::Utils;
+use Sauron::SetupIO;
 use Net::IP qw(:PROC);
 use strict;
 use List::Util qw[min max];
@@ -25,7 +26,7 @@ sub write2log{
   my $filename  = File::Basename::basename($0);
 
   Sys::Syslog::openlog($filename, "cons,pid", "debug");
-  Sys::Syslog::syslog("info", "$msg");
+  Sys::Syslog::syslog("info", encode_str("$msg"));
   Sys::Syslog::closelog();
 } # End of write2log
 

--- a/Sauron/CGI/Utils.pm
+++ b/Sauron/CGI/Utils.pm
@@ -12,6 +12,7 @@ use Sauron::CGIutil;
 use Sauron::BackEnd;
 use Sauron::Util;
 use Sauron::Sauron;
+use Sauron::SetupIO;
 use strict;
 use vars qw($VERSION @ISA @EXPORT);
 use Sys::Syslog qw(:DEFAULT setlogsock);
@@ -56,7 +57,7 @@ sub write2log{
   my $filename  = File::Basename::basename($0);
 
   Sys::Syslog::openlog($filename, "cons,pid", "debug");
-  Sys::Syslog::syslog("info", "$msg");
+  Sys::Syslog::syslog("info", encode_str("$msg"));
   Sys::Syslog::closelog();
 } # End of write2log
 

--- a/Sauron/CGI/Zones.pm
+++ b/Sauron/CGI/Zones.pm
@@ -13,6 +13,7 @@ use Sauron::BackEnd;
 use Sauron::Sauron;
 use Sauron::Util;
 use Sauron::CGI::Utils;
+use Sauron::SetupIO;
 use strict;
 use vars qw($VERSION @ISA @EXPORT);
 use Sys::Syslog qw(:DEFAULT setlogsock);
@@ -30,7 +31,7 @@ sub write2log{
   my $filename  = File::Basename::basename($0);
 
   Sys::Syslog::openlog($filename, "cons,pid", "debug");
-  Sys::Syslog::syslog("info", "$msg");
+  Sys::Syslog::syslog("info", encode_str("$msg"));
   Sys::Syslog::closelog();
 } # End of write2log
 

--- a/Sauron/DB-DBI.pm
+++ b/Sauron/DB-DBI.pm
@@ -7,6 +7,7 @@ require Exporter;
 use Time::Local;
 use DBI;
 use Sauron::Util;
+use Sauron::SetupIO;
 use strict;
 use vars qw($VERSION @ISA @EXPORT);
 
@@ -48,7 +49,7 @@ sub write2log
   my $filename  = File::Basename::basename($0);
 
   Sys::Syslog::openlog($filename, "cons,pid", "debug");
-  Sys::Syslog::syslog("info", "$msg");
+  Sys::Syslog::syslog("info", encode_str("$msg"));
   Sys::Syslog::closelog();
 } # End of write2log
 

--- a/Sauron/Sauron.pm
+++ b/Sauron/Sauron.pm
@@ -7,13 +7,13 @@
 package Sauron::Sauron;
 require Exporter;
 use Sauron::Util;
+use Sauron::SetupIO;
 use MIME::Base64 qw(decode_base64);
 use strict;
 use vars qw($VERSION $CONF_FILE_PATH @ISA @EXPORT);
 
 $VERSION = '$Id:$ ';
 $CONF_FILE_PATH = '__CONF_FILE_PATH__';
-
 
 @ISA = qw(Exporter); # Inherit from Exporter
 @EXPORT = qw(
@@ -25,15 +25,10 @@ $CONF_FILE_PATH = '__CONF_FILE_PATH__';
 	     print_browser_config
 	    );
 
-# A hack adapted from following page, mesrik - 2024
-# - https://stackoverflow.com/questions/627661/how-can-i-output-utf-8-from-perl
-binmode(STDOUT, ":utf8");          #treat as if it is UTF-8
-binmode(STDIN, ":encoding(utf8)"); #actually check if it is UTF-8
 
 sub sauron_version() {
   return "0.9.0 (beta)"; # current Sauron version
 }
-
 
 sub set_defaults() {
   undef $main::CONFIG_FILE;

--- a/Sauron/SetupIO.pm
+++ b/Sauron/SetupIO.pm
@@ -1,0 +1,45 @@
+# Sauron::SetupIO.pm - Setup input/output charset
+#
+# Copyright (c) Michal Svamberg <svamberg@cesnet.cz> 2025.
+# Copyright (c) Michal Kostenec <kostenec@civ.zcu.cz> 2013-2014.
+# Copyright (c) Timo Kokkonen <tjko@iki.fi> 2002.
+# $Id:$
+#
+# About handling with charset in perl see 
+# https://dev.to/drhyde/a-brief-guide-to-perl-character-encoding-if7
+#
+package Sauron::SetupIO;
+require Exporter;
+use Encode qw(decode encode);
+use Encode::Locale qw($ENCODING_LOCALE); # set encoding by locale (argv, stdin/out/err)
+use strict;
+use vars qw($VERSION @ISA @EXPORT);
+
+$VERSION = '$Id:$ ';
+
+@ISA = qw(Exporter); # Inherit from Exporter
+@EXPORT = qw(
+             set_encoding
+             encode_str
+            );
+
+# reset to actual encoding
+sub set_encoding {
+    # set encoding for standard filehanders
+    binmode(STDIN,  ":encoding(locale)");
+    binmode(STDOUT, ":encoding(locale)");
+    binmode(STDERR, ":encoding(locale)");
+
+    # decode @ARGV to perl internal representation
+    @ARGV = map { decode('locale', $_) } @ARGV;
+
+    return $ENCODING_LOCALE; # return actual LOCALE string
+}
+
+# encode to bytes (not wide chars)
+sub encode_str {
+    return encode('locale', shift @_);
+}
+
+1;
+# eof

--- a/Sauron/Util.pm
+++ b/Sauron/Util.pm
@@ -6,6 +6,7 @@
 #
 package Sauron::Util;
 require Exporter;
+use Sauron::SetupIO;
 use Time::Local 'timelocal_nocheck';
 use Digest::MD5;
 # use Net::Netmask;
@@ -21,7 +22,7 @@ sub write2log{
   my $filename  = File::Basename::basename($0);
 
   Sys::Syslog::openlog($filename, "cons,pid", "debug");
-  Sys::Syslog::syslog("info", "$msg");
+  Sys::Syslog::syslog("info", encode_str("$msg"));
   Sys::Syslog::closelog();
 } # End of write2log
 

--- a/addgroup
+++ b/addgroup
@@ -11,7 +11,9 @@ use Sauron::DB;
 use Sauron::Util;
 use Sauron::BackEnd;
 use Sauron::Sauron;
+use Sauron::SetupIO;
 
+set_encoding();
 load_config();
 
 GetOptions("help|h","name=s","group=s","priv=s"); # priv 16.03.2017 TVu

--- a/addhosts
+++ b/addhosts
@@ -14,8 +14,10 @@ use Sauron::Util;
 use Sauron::UtilZone;
 use Sauron::BackEnd;
 use Sauron::Sauron;
-load_config();
+use Sauron::SetupIO;
 
+set_encoding();
+load_config();
 
 $user = (getpwuid($<))[0];
 set_muser($user);

--- a/addipv6
+++ b/addipv6
@@ -12,10 +12,12 @@ use Sauron::DB;
 use Sauron::Util;
 use Sauron::BackEnd;
 use Sauron::Sauron;
+use Sauron::SetupIO;
 use Pod::Usage;
 use strict;
 use warnings;
 
+set_encoding();
 load_config();
 
 # Local variables.

--- a/adduser
+++ b/adduser
@@ -12,7 +12,9 @@ use Sauron::DB;
 use Sauron::Util;
 use Sauron::BackEnd;
 use Sauron::Sauron;
+use Sauron::SetupIO;
 
+set_encoding();
 load_config();
 
 $user = (getpwuid($<))[0];

--- a/check-pending
+++ b/check-pending
@@ -9,7 +9,9 @@ require 5;
 use Getopt::Long;
 use Sauron::Util;
 use Sauron::Sauron;
+use Sauron::SetupIO;
 
+set_encoding();
 load_config();
 
 $MAXLINES = 100;

--- a/createtables
+++ b/createtables
@@ -12,7 +12,9 @@ use Sauron::DB;
 use Sauron::Util;
 use Sauron::BackEnd;
 use Sauron::Sauron;
+use Sauron::SetupIO;
 
+set_encoding();
 load_config();
 
 @TABLES  =  qw@ sql/common.sql

--- a/dbcheck
+++ b/dbcheck
@@ -13,12 +13,14 @@ use Sauron::DB;
 use Sauron::BackEnd;
 use Sauron::Sauron;
 use Sauron::Util;
+use Sauron::SetupIO;
 use Pod::Usage;
 use File::Temp qw/ tempfile tempdir /;
 use Term::ReadLine;
 use strict;
 use warnings;
 
+set_encoding();
 load_config();
 
 # Local variables.

--- a/delgroup
+++ b/delgroup
@@ -11,7 +11,9 @@ use Sauron::DB;
 use Sauron::Util;
 use Sauron::BackEnd;
 use Sauron::Sauron;
+use Sauron::SetupIO;
 
+set_encoding();
 load_config();
 
 ##############################################

--- a/deluser
+++ b/deluser
@@ -11,7 +11,9 @@ use Sauron::DB;
 use Sauron::Util;
 use Sauron::BackEnd;
 use Sauron::Sauron;
+use Sauron::SetupIO;
 
+set_encoding();
 load_config();
 
 ##############################################

--- a/expire-hosts
+++ b/expire-hosts
@@ -14,8 +14,11 @@ use Sauron::DB;
 use Sauron::Util;
 use Sauron::BackEnd;
 use Sauron::Sauron;
+use Sauron::SetupIO;
 use strict;
 use warnings;
+
+set_encoding();
 
 sub sql_array_str($$@) {
     my ($ss,$tc,@arr) = (@_); # split string, type cast, array

--- a/export-by-group
+++ b/export-by-group
@@ -13,8 +13,10 @@ use Sauron::DB;
 use Sauron::Util;
 use Sauron::BackEnd;
 use Sauron::Sauron;
+use Sauron::SetupIO;
 use strict;
 
+set_encoding();
 load_config();
 
 my $user = (getpwuid($<))[0];

--- a/export-hosts
+++ b/export-hosts
@@ -14,9 +14,11 @@ use Sauron::DB;
 use Sauron::Util;
 use Sauron::BackEnd;
 use Sauron::Sauron;
+use Sauron::SetupIO;
 use Data::Dumper;
 use strict;
 
+set_encoding();
 
 my(@zones);
 

--- a/export-ip-list
+++ b/export-ip-list
@@ -14,10 +14,12 @@ use Sauron::DB;
 use Sauron::Util;
 use Sauron::BackEnd;
 use Sauron::Sauron;
+use Sauron::SetupIO;
 use Net::IP;
 
 sub optimize_ip_list($);
 
+set_encoding();
 load_config();
 
 $user = (getpwuid($<))[0];

--- a/export-networks
+++ b/export-networks
@@ -14,7 +14,9 @@ use Sauron::DB;
 use Sauron::Util;
 use Sauron::BackEnd;
 use Sauron::Sauron;
+use Sauron::SetupIO;
 
+set_encoding();
 load_config();
 
 $VER = sauron_version();

--- a/export-vmps
+++ b/export-vmps
@@ -12,7 +12,9 @@ use Sauron::DB;
 use Sauron::Util;
 use Sauron::BackEnd;
 use Sauron::Sauron;
+use Sauron::SetupIO;
 
+set_encoding();
 load_config();
 
 $user = (getpwuid($<))[0];

--- a/generatehosts
+++ b/generatehosts
@@ -13,8 +13,10 @@ use Sauron::DB;
 use Sauron::Util;
 use Sauron::BackEnd;
 use Sauron::Sauron;
+use Sauron::SetupIO;
 use Net::IP qw(:PROC);
 
+set_encoding();
 load_config();
 
 #######################################################################

--- a/import
+++ b/import
@@ -15,8 +15,10 @@ use Sauron::Util;
 use Sauron::UtilZone;
 use Sauron::BackEnd;
 use Sauron::Sauron;
+use Sauron::SetupIO;
 use Net::IP qw(:PROC);
 
+set_encoding();
 load_config();
 
 # if these are not defined, then values are taken from first master zone

--- a/import-dhcp
+++ b/import-dhcp
@@ -15,8 +15,10 @@ use Sauron::Util;
 use Sauron::UtilDhcp;
 use Sauron::BackEnd;
 use Sauron::Sauron;
+use Sauron::SetupIO;
 use Net::IP;
 
+set_encoding();
 load_config();
 
 ##############################

--- a/import-ethers
+++ b/import-ethers
@@ -12,7 +12,9 @@ use Getopt::Long;
 use Sauron::DB;
 use Sauron::Util;
 use Sauron::Sauron;
+use Sauron::SetupIO;
 
+set_encoding();
 load_config();
 
 ###################################################################

--- a/import-jyu
+++ b/import-jyu
@@ -29,7 +29,9 @@ use Sauron::Util;
 use Sauron::UtilZone;
 use Sauron::BackEnd;
 use Sauron::Sauron;
+use Sauron::SetupIO;
 
+set_encoding();
 load_config();
 
 ##############################

--- a/import-nets
+++ b/import-nets
@@ -10,7 +10,9 @@ use Sauron::DB;
 use Sauron::BackEnd;
 use Sauron::Util;
 use Sauron::Sauron;
+use Sauron::SetupIO;
 
+set_encoding();
 $|=1;
 load_config();
 

--- a/import-roots
+++ b/import-roots
@@ -12,7 +12,9 @@ use Sauron::Util;
 use Sauron::UtilZone;
 use Sauron::BackEnd;
 use Sauron::Sauron;
+use Sauron::SetupIO;
 
+set_encoding();
 load_config();
 
 ###################################################################

--- a/import-zone
+++ b/import-zone
@@ -14,7 +14,9 @@ use Sauron::Util;
 use Sauron::UtilZone;
 use Sauron::BackEnd;
 use Sauron::Sauron;
+use Sauron::SetupIO;
 
+set_encoding();
 load_config();
 
 ##############################

--- a/keygen
+++ b/keygen
@@ -14,6 +14,7 @@ use Sauron::BackEnd;
 use Digest::MD5;
 use MIME::Base64;
 use Crypt::RC5;
+use Sauron::SetupIO;
 
 my %KEY_ALGORITHMS = ( 
 		       0=>'reserved',
@@ -24,6 +25,7 @@ my %KEY_ALGORITHMS = (
 		       157=>'HMAC-MD5'
 		      );
 
+set_encoding();
 load_config();
 
 GetOptions("help|h","setmasterkey:s","add:s","del:s","regen:s","list:s",

--- a/last
+++ b/last
@@ -12,8 +12,10 @@ use Sauron::DB;
 use Sauron::Util;
 use Sauron::BackEnd;
 use Sauron::Sauron;
+use Sauron::SetupIO;
 use Text::Table;
 
+set_encoding();
 load_config();
 
 ##############################################

--- a/modhosts
+++ b/modhosts
@@ -16,9 +16,11 @@ use Sauron::DB;
 use Sauron::Util;
 use Sauron::BackEnd;
 use Sauron::Sauron;
+use Sauron::SetupIO;
 use Net::IP qw(:PROC);
 use Data::Dumper;
 
+set_encoding();
 load_config();
 
 ##############################################

--- a/moduser
+++ b/moduser
@@ -13,11 +13,13 @@ use Sauron::DB;
 use Sauron::Util;
 use Sauron::BackEnd;
 use Sauron::Sauron;
+use Sauron::SetupIO;
 use Text::Table;
 
 my ($PG_DIR,$PG_NAME) = ($0 =~ /^(.*\/)(.*)$/);
 $0 = $PG_NAME;
 
+set_encoding();
 load_config();
 
 my $modgroup = ($PG_NAME eq 'modgroup' ? 1 : 0);

--- a/remove-hosts
+++ b/remove-hosts
@@ -11,7 +11,9 @@ use Sauron::DB;
 use Sauron::BackEnd;
 use Sauron::Util;
 use Sauron::Sauron;
+use Sauron::SetupIO;
 
+set_encoding();
 load_config();
 
 GetOptions("help|h","mac","duid","ip","host","commit");

--- a/runsql
+++ b/runsql
@@ -10,7 +10,9 @@ use Getopt::Long;
 use Sauron::DB;
 use Sauron::Util;
 use Sauron::Sauron;
+use Sauron::SetupIO;
 
+set_encoding();
 load_config();
 
 ##############################################

--- a/sauron
+++ b/sauron
@@ -16,7 +16,10 @@ use Sauron::Util;
 use Sauron::DB;
 use Sauron::BackEnd;
 use Sauron::Sauron;
+use Sauron::SetupIO;
 use Net::IP qw(:PROC);
+
+set_encoding();
 load_config();
 
 $bind_conf=0;

--- a/sql/common.sql
+++ b/sql/common.sql
@@ -8,9 +8,9 @@
 
 CREATE TABLE common_fields ( 
        cdate	   INT4, /* creation date */
-       cuser	   CHAR(8) DEFAULT 'unknown',   /* creating user */
+       cuser	   CHAR(321) DEFAULT 'unknown',   /* creating user */
        mdate	   INT4, /* modification date */
-       muser	   CHAR(8) DEFAULT 'unknown', /* last changed by this user */
+       muser	   CHAR(321) DEFAULT 'unknown', /* last changed by this user */
        expiration  INT4  /* expiration date */
 );
 

--- a/sql/dbconvert_1.7to1.8
+++ b/sql/dbconvert_1.7to1.8
@@ -1,0 +1,13 @@
+/* convert Sauron database format from 1.7 to 1.8 */
+/* (this requires PostgreSQL v7.3 or later) */
+
+
+/* resize user login */
+ALTER TABLE common_fields ALTER COLUMN cuser TYPE CHAR(321);
+
+/* resize user login */
+ALTER TABLE common_fields ALTER COLUMN muser TYPE CHAR(321);
+
+UPDATE settings SET value='1.8' where setting='dbversion';
+
+/* eof */

--- a/status
+++ b/status
@@ -12,6 +12,7 @@ use Sauron::DB;
 use Sauron::Util;
 use Sauron::BackEnd;
 use Sauron::Sauron;
+use Sauron::SetupIO;
 require Sauron::CGIutil;
 require Sauron::UtilDhcp;
 require Sauron::UtilZone;
@@ -19,6 +20,7 @@ require CGI;
 require Net::DNS;
 require Net::IP;
 
+set_encoding();
 load_config();
 
 ##############################################

--- a/update-dhcp-info
+++ b/update-dhcp-info
@@ -21,8 +21,10 @@ use Sauron::DB;
 use Sauron::Util;
 use Sauron::BackEnd;
 use Sauron::Sauron;
+use Sauron::SetupIO;
 use Data::Dumper;
 
+set_encoding();
 load_config();
 
 my (%months) = (Jan=>0,Feb=>1,Mar=>2,Apr=>3,May=>4,Jun=>5,

--- a/update-hosts
+++ b/update-hosts
@@ -11,7 +11,9 @@ use Sauron::DB;
 use Sauron::BackEnd;
 use Sauron::Util;
 use Sauron::Sauron;
+use Sauron::SetupIO;
 
+set_encoding();
 $|=1;
 load_config();
 


### PR DESCRIPTION
Added Sauron::SetupIO module for correct encoding settings

Before:
```bash
# /opt/sauron/adduser --user='7f2a0a81789859b9f50c8dc35f97dc495ff6eb01@einfra.cesnet.cz' --passwd='XXX' --email='jiri.mensik@cesnet.cz' --name='Jiří Menšík'
User 7f2a0a81789859b9f50c8dc35f97dc495ff6eb01@einfra.cesnet.cz added successfully.
Remember to give user some rights with moduser command.
# /opt/sauron/moduser --list
Login                                                     Group Email                 Flags Name
-----------------------------------------------------------------------------------------------------------
7f2a0a81789859b9f50c8dc35f97dc495ff6eb01@einfra.cesnet.cz       jiri.mensik@cesnet.cz 0     JiÅÃ MenÅ¡Ãk
```

After:
```bash
# /opt/sauron/adduser --user='7f2a0a81789859b9f50c8dc35f97dc495ff6eb01@einfra.cesnet.cz' --passwd='XXX' --email='jiri.mensik@cesnet.cz' --name='Jiří Menšík'
User 7f2a0a81789859b9f50c8dc35f97dc495ff6eb01@einfra.cesnet.cz added successfully.
Remember to give user some rights with moduser command.
# /opt/sauron/moduser --list
Login                                                     Group Email                 Flags Name       
-------------------------------------------------------------------------------------------------------
7f2a0a81789859b9f50c8dc35f97dc495ff6eb01@einfra.cesnet.cz       jiri.mensik@cesnet.cz 0     Jiří Menšík
```