### PR TITLE
Replace deprecated Crypt::RC5 with Crypt::Cipher::RC5

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,7 @@
 	  of eduPersonUniqueId according to RFC4512. [svamberg]
 	- Removed 'WITH OIDS' from SQL table creation; not supported since 
 	  version 12. [svamberg]
+	- change libcrypt-cb5-perl to libcryptx-perl [svamberg]
 
 0.8.5
 

--- a/README
+++ b/README
@@ -21,7 +21,7 @@ REQUIREMENTS
 		- Digest::HMAC module
 		- Digest::SHA1 module
 		- MIME::Base64
-		- Crypt::RC5
+		- Crypt::Cipher::RC5
 		- Text::Table;
  	- PostgresSQL [15.10 or newer  recommended]
 	  (or add support to your favorite db yourself :)

--- a/keygen
+++ b/keygen
@@ -13,7 +13,7 @@ use Sauron::Sauron;
 use Sauron::BackEnd;
 use Digest::MD5;
 use MIME::Base64;
-use Crypt::RC5;
+use Crypt::Cipher::RC5;
 use Sauron::SetupIO;
 
 my %KEY_ALGORITHMS = ( 
@@ -244,9 +244,9 @@ sub setmasterkey($) {
 	    fatal("unsupported key: $name (algorithm=$algo)") 
 	      if ($algo != 157);
 	    if ($keys[$i][1]) {
-		my $ref1 = Crypt::RC5->new($oldkey,16);
+		my $ref1 = Crypt::Cipher::RC5->new($oldkey,16);
 		my $okey=$ref1->decrypt(decode_base64($keys[$i][1]));
-		my $ref2 = Crypt::RC5->new($key,16);
+		my $ref2 = Crypt::Cipher::RC5->new($key,16);
 		my $nkey=encode_base64($ref2->encrypt($okey));
 		chomp($nkey);
 		if (db_exec("UPDATE keys SET secretkey='$nkey' " .
@@ -303,7 +303,7 @@ sub addkey() {
     } else {
 	print "Generating key...\n";
 	my $okey = generate_key($name,$type,$len);
-	my $ref = Crypt::RC5->new($SAURON_KEY,16);
+	my $ref = Crypt::Cipher::RC5->new($SAURON_KEY,16);
 	$key=encode_base64($ref->encrypt(decode_base64($okey)));
 	print "Key: $okey  Encrypted-Key: $key\n" if ($opt_verbose);
 	$mode=0;
@@ -383,7 +383,7 @@ sub regenkeys($) {
 
     print "Generating key: $name ...\n";
     my $okey = generate_key($name,$type,$len);
-    my $ref = Crypt::RC5->new($SAURON_KEY,16);
+    my $ref = Crypt::Cipher::RC5->new($SAURON_KEY,16);
     my $key=encode_base64($ref->encrypt(decode_base64($okey)));
     chomp($key);
     print "Key: $okey  Encrypted-Key: $key\n" if ($opt_verbose);

--- a/sauron
+++ b/sauron
@@ -11,7 +11,7 @@ require 5;
 use NetAddr::IP; # For IPv6.
 use Getopt::Long;
 use MIME::Base64;
-use Crypt::RC5;
+use Crypt::Cipher::RC5;
 use Sauron::Util;
 use Sauron::DB;
 use Sauron::BackEnd;
@@ -2999,7 +2999,7 @@ sub print_keys_acls($) {
 		  error("Skipping key with empty secret key: $name");
 		  next;
 	      }
-	      my $h = Crypt::RC5->new($SAURON_KEY,16);
+	      my $h = Crypt::Cipher::RC5->new($SAURON_KEY,16);
 	      my $dkey = encode_base64($h->decrypt(decode_base64($key)));
 	      chomp($dkey);
 


### PR DESCRIPTION
- All relevant code in keygen and sauron has been updated to use Crypt::Cipher::RC5.
- README now reflects the dependency change