### PR TITLE
Fix encoding in open function

### DIFF
--- a/Sauron/CGI/Utils.pm
+++ b/Sauron/CGI/Utils.pm
@@ -17,6 +17,7 @@ use strict;
 use vars qw($VERSION @ISA @EXPORT);
 use Sys::Syslog qw(:DEFAULT setlogsock);
 Sys::Syslog::setlogsock('unix');
+use open ':locale';
 
 $VERSION = '$Id:$ ';
 

--- a/Sauron/Sauron.pm
+++ b/Sauron/Sauron.pm
@@ -11,6 +11,7 @@ use Sauron::SetupIO;
 use MIME::Base64 qw(decode_base64);
 use strict;
 use vars qw($VERSION $CONF_FILE_PATH @ISA @EXPORT);
+use open ':locale';
 
 $VERSION = '$Id:$ ';
 $CONF_FILE_PATH = '__CONF_FILE_PATH__';

--- a/Sauron/Util.pm
+++ b/Sauron/Util.pm
@@ -16,6 +16,7 @@ use strict;
 use vars qw($VERSION @ISA @EXPORT);
 use Sys::Syslog qw(:DEFAULT setlogsock);
 Sys::Syslog::setlogsock('unix');
+use open ':locale';
 
 sub write2log{
   my $msg       = shift;

--- a/Sauron/UtilDhcp.pm
+++ b/Sauron/UtilDhcp.pm
@@ -10,6 +10,7 @@ use IO::File;
 use Sauron::Util;
 use strict;
 use vars qw($VERSION @ISA @EXPORT);
+use open ':locale';
 
 $VERSION = '$Id:$ ';
 

--- a/Sauron/UtilZone.pm
+++ b/Sauron/UtilZone.pm
@@ -12,6 +12,7 @@ use Net::IP qw(:PROC);
 use Sauron::Util;
 use strict;
 use vars qw($VERSION @ISA @EXPORT);
+use open ':locale';
 
 $VERSION = '$Id:$ ';
 

--- a/cgi/sauron.cgi
+++ b/cgi/sauron.cgi
@@ -19,6 +19,7 @@ use Sauron::Sauron;
 use Data::Dumper;
 #use strict;
 use warnings;;
+use open ':locale';
 
 $CGI::DISABLE_UPLOADS = 1; # no uploads
 $CGI::POST_MAX = 100000; # max 100k posts

--- a/check-pending
+++ b/check-pending
@@ -10,6 +10,7 @@ use Getopt::Long;
 use Sauron::Util;
 use Sauron::Sauron;
 use Sauron::SetupIO;
+use open ':locale';
 
 set_encoding();
 load_config();

--- a/dbcheck
+++ b/dbcheck
@@ -17,6 +17,7 @@ use Sauron::SetupIO;
 use Pod::Usage;
 use File::Temp qw/ tempfile tempdir /;
 use Term::ReadLine;
+use open ':locale';
 use strict;
 use warnings;
 

--- a/export-vmps
+++ b/export-vmps
@@ -13,6 +13,7 @@ use Sauron::Util;
 use Sauron::BackEnd;
 use Sauron::Sauron;
 use Sauron::SetupIO;
+use open ':locale';
 
 set_encoding();
 load_config();

--- a/import
+++ b/import
@@ -17,6 +17,7 @@ use Sauron::BackEnd;
 use Sauron::Sauron;
 use Sauron::SetupIO;
 use Net::IP qw(:PROC);
+use open ':locale';
 
 set_encoding();
 load_config();

--- a/import-ethers
+++ b/import-ethers
@@ -13,6 +13,7 @@ use Sauron::DB;
 use Sauron::Util;
 use Sauron::Sauron;
 use Sauron::SetupIO;
+use open ':locale';
 
 set_encoding();
 load_config();

--- a/import-nets
+++ b/import-nets
@@ -11,6 +11,7 @@ use Sauron::BackEnd;
 use Sauron::Util;
 use Sauron::Sauron;
 use Sauron::SetupIO;
+use open ':locale';
 
 set_encoding();
 $|=1;

--- a/keygen
+++ b/keygen
@@ -15,6 +15,7 @@ use Digest::MD5;
 use MIME::Base64;
 use Crypt::RC5;
 use Sauron::SetupIO;
+use open ':locale';
 
 my %KEY_ALGORITHMS = ( 
 		       0=>'reserved',

--- a/remove-hosts
+++ b/remove-hosts
@@ -12,6 +12,7 @@ use Sauron::BackEnd;
 use Sauron::Util;
 use Sauron::Sauron;
 use Sauron::SetupIO;
+use open ':locale';
 
 set_encoding();
 load_config();

--- a/runsql
+++ b/runsql
@@ -11,6 +11,7 @@ use Sauron::DB;
 use Sauron::Util;
 use Sauron::Sauron;
 use Sauron::SetupIO;
+use open ':locale';
 
 set_encoding();
 load_config();

--- a/sauron
+++ b/sauron
@@ -18,6 +18,7 @@ use Sauron::BackEnd;
 use Sauron::Sauron;
 use Sauron::SetupIO;
 use Net::IP qw(:PROC);
+use open ':locale';
 
 set_encoding();
 load_config();

--- a/solaris/makesvr4pkg.pl
+++ b/solaris/makesvr4pkg.pl
@@ -7,6 +7,7 @@
 #
 use File::Path;
 use Getopt::Long;
+use open ':locale';
 
 my @SYS_DIRS = qw#
     /etc 

--- a/update-dhcp-info
+++ b/update-dhcp-info
@@ -23,6 +23,7 @@ use Sauron::BackEnd;
 use Sauron::Sauron;
 use Sauron::SetupIO;
 use Data::Dumper;
+use open ':locale';
 
 set_encoding();
 load_config();

--- a/update-hosts
+++ b/update-hosts
@@ -12,6 +12,7 @@ use Sauron::BackEnd;
 use Sauron::Util;
 use Sauron::Sauron;
 use Sauron::SetupIO;
+use open ':locale';
 
 set_encoding();
 $|=1;


### PR DESCRIPTION
- Added 'use open (:locale);' to scripts and modules
- Ensures UTF-8 and locale-aware behavior for input/output operations based on the user's environment

This patch solves this problem at line 5:
```bash
1  ./sauron --bind dns.cesnet.cz
2  Server 'dns.cesnet.cz' has 1 zones.
3  BIND configuration
4  Generating named.zones...
5  Wide character in print at ./sauron line 190.
6  sauron: empty named.ca
```