### PR TITLE
Adds a reset of $db_last_id before running the query

### DIFF
--- a/Sauron/DB-DBI.pm
+++ b/Sauron/DB-DBI.pm
@@ -101,6 +101,7 @@ sub db_exec($) {
 
 # $db_last_oid=$sth->{pg_oid_status}; # ** Removed 2018-09-25 TVu
 # eval { $db_last_id = $sth->fetch()->[0]; }; # ** Added 2018-09-25 TVu
+  $db_last_id = -1; # reset if eval() fails
   eval { # ** Added 2018-10-01 TVu
       $db_last_id = $sqlstr =~ /returning/i ? $sth->fetch()->[0] : -1;
   };


### PR DESCRIPTION
Problem solved: If a RETURNING clause in db_exec() produces no rows, eval swallows the exception and $db_last_id retains its previous value - potentially assigning a wrong foreign key/reference.