### PR TITLE
Enable strict mode and harden CGI parameter handling

### DIFF
--- a/Sauron/CGIutil.pm
+++ b/Sauron/CGIutil.pm
@@ -1379,6 +1379,7 @@ sub form_magic($$$) {
           # inner param must run in scalar context to avoid CGI warning
           my $val = scalar(param($p1));
           param($p1."_l", $val);
+          param($p1,'');
       }
 
       print td($rec->{name}),"<TD>",

--- a/Sauron/CGIutil.pm
+++ b/Sauron/CGIutil.pm
@@ -683,18 +683,21 @@ sub form_field_enum($$$$) {
     }
     $lsth{''} = '';
   }
-  if (defined $lsth{param($n)} && (param($n) ne '')) {
-    param($n."_enum",param($n));
+  # fetch values safely in scalar context
+  my $cur   = scalar(param($n));
+  my $cur_e = scalar(param($n . "_enum"));
+  if (defined $lsth{$cur} && ($cur ne '')) {
+    param($n . "_enum", $cur);
     param($n,'');
   }
   print "<TD>",
     popup_menu(
       -name=>$n."_enum",
       -values=>\@lst,
-      -value=>param($n."_enum") ? param($n."_enum") : $lst[0],
+      -value=> $cur_e ? $cur_e : $lst[0],
       -labels=>\%lsth),
     " ",
-    textfield(-name=>$n,-size=>$len,-maxlength=>$maxlen,-value=>param($n));
+    textfield(-name=>$n,-size=>$len,-maxlength=>$maxlen,-value=>$cur);
   if ($update > 0) {
     my $tmp=param($n);
     $tmp=param($n."_enum") if ($tmp eq '');

--- a/Sauron/CGIutil.pm
+++ b/Sauron/CGIutil.pm
@@ -1373,8 +1373,9 @@ sub form_magic($$$) {
 	if (param($p1) eq '' && ($lst[0] ne '') && (not param($p1."_l")));
 
       if ($lsth{param($p1)} && (param($p1) ne '')) {
-	param($p1."_l",param($p1));
-	param($p1,'');
+          # inner param must run in scalar context to avoid CGI warning
+          my $val = scalar(param($p1));
+          param($p1."_l", $val);
       }
 
       print td($rec->{name}),"<TD>",

--- a/cgi/browser.cgi
+++ b/cgi/browser.cgi
@@ -15,6 +15,21 @@ use Sauron::Util;
 use Sauron::BackEnd;
 use Sauron::CGIutil;
 use Sauron::Sauron;
+use strict;
+use warnings;
+
+# global variables for strict/warnings
+use vars qw(
+    $debug_mode %host_types %host_form
+    $res $VER $pathinfo $script_name $s_url $selfurl
+    $remote_addr $remote_host $server $zone
+    $serverid $zoneid $help_str $show_max
+    $min $hour $mday $mon $year $timestamp
+    @search_types $key
+    $BROWSER_CONF $BROWSER_HELP $BROWSER_MAX $BROWSER_CHARSET $BROWSER_SHOW_FIELDS
+    $BROWSER_HIDE_PRIVATE $BROWSER_HIDE_FIELDS
+    $bgcolor
+);
 
 $CGI::DISABLE_UPLOADS = 1; # no uploads
 $CGI::POST_MAX = 10000; # max 10k posts
@@ -146,12 +161,19 @@ print header(-charset=>$BROWSER_CHARSET),
       "<!-- Copyright (c) Timo Kokkonen <tjko\@iki.fi>  2001-2005. -->\n\n";
 
 
-$key = $pathinfo;
+$key = $pathinfo || '';
 $key =~ s/[^a-z0-9\-]//g;
 
-html_error2("Invalid parameters!") unless (@{$$BROWSER_CONF{$key}} == 2);
-$server=$$BROWSER_CONF{$key}[0];
-$zone=$$BROWSER_CONF{$key}[1];
+# make sure we have a valid configuration entry before dereferencing
+unless (defined $key
+        && length $key
+        && exists $BROWSER_CONF->{$key}
+        && ref($$BROWSER_CONF{$key}) eq 'ARRAY'
+        && @{$$BROWSER_CONF{$key}} == 2) {
+    html_error2("Invalid parameters!");
+}
+$server = $$BROWSER_CONF{$key}[0];
+$zone   = $$BROWSER_CONF{$key}[1];
 
 #print "server '$server', zone '$zone'\n";
 
@@ -163,9 +185,15 @@ html_error2("Invalid configuration: cannot find zone") unless ($zoneid>0);
 cgi_util_set_zone($zoneid,$zone);
 cgi_util_set_server($serverid,$server);
 
-$help_str = ( @{$$BROWSER_HELP{$key}} == 2 ?
-	  "<a href=\"$$BROWSER_HELP{$key}[1]\">$$BROWSER_HELP{$key}[0]</a>" :
-          "&nbsp;" );
+# safely build help link if configuration exists
+if (defined $key
+    && exists $BROWSER_HELP->{$key}
+    && ref($$BROWSER_HELP{$key}) eq 'ARRAY'
+    && @{$$BROWSER_HELP{$key}} == 2) {
+    $help_str = "<a href=\"$$BROWSER_HELP{$key}[1]\">$$BROWSER_HELP{$key}[0]</a>";
+} else {
+    $help_str = "&nbsp;";
+}
 
 $show_max=($BROWSER_MAX > 0 ? $BROWSER_MAX : 100);
 
@@ -203,10 +231,13 @@ print start_form(-method=>'POST',-action=>$selfurl),
       end_form,"</TD></TR>",
       "</TABLE>\n";
 
-if (($id=int(param('id'))) > 0) {
-  display_host($id);
-} else {
-  do_search();
+{
+    my $id = int(param('id'));
+    if ($id > 0) {
+      display_host($id);
+    } else {
+      do_search();
+    }
 }
 
 
@@ -216,6 +247,7 @@ if ($debug_mode) {
         "<br>s_url='$s_url' '$selfurl'\n",
         "<br>url()=" . url(),
         "<p>remote_addr=$remote_addr<p>";
+  my (@names, $var);
   @names = param();
   foreach $var (@names) { print "$var = '" . param($var) . "'<br>\n"; }
   print "<hr><p>\n";
@@ -227,9 +259,14 @@ exit;
 #####################################################################
 
 sub do_search() {
-  $type=param('type');
-  $mask=param('mask');
-
+    my $type = param('type');
+    my $mask = param('mask');
+    my ($info_search, $order, $mask_str, $rule, $alias, @irules);
+    my ($sql, $sql2, $sql2b, $sql3, $sortparam);
+    my (@q, $count, $url);
+    my (@nlist, $i, $color);
+    # variables used later when printing rows
+    my ($name, $ip, $ether, $info);
   unless (valid_safe_string($type,255) and valid_safe_string($mask,255)) {
     alert2("Invalid input!");
     return;
@@ -342,6 +379,9 @@ sub do_search() {
 
   print "<TABLE width=\"100%\" cellspacing=1 cellpadding=1 border=0>",
         "<TR><TD height=2></TD></TR></TABLE>";
+
+    # counter for printed rows
+    my $printcount = 0;
   print "<TABLE width=\"100%\" cellspacing=1 cellpadding=1 border=0 " .
         "  bgcolor=\"#ccccff\">\n",
         "<TR bgcolor=\"aaaaee\">",th("#"),
@@ -435,7 +475,8 @@ sub do_search() {
 
 sub display_host($) {
   my($id) = @_;
-  my(@q, @r, $i, $j, $url);
+  my(@q, @r, $i, $j, $url, $k);
+  my %host;
 
   if (get_host($id,\%host)) {
     alert2("Cannot get host record (id=$id)");
@@ -476,8 +517,6 @@ sub display_host($) {
 
   display_form(\%host,\%host_form);
 }
-
-
 
 # eof
 

--- a/cgi/sauron.cgi
+++ b/cgi/sauron.cgi
@@ -17,9 +17,33 @@ use Sauron::CGI::Utils;
 use Sauron::Sauron;
 use HTML::Entities;
 use Data::Dumper;
-#use strict;
-use warnings;;
+use strict;
+use warnings;
 use open ':locale';
+
+# variables used globally; needed with strict
+use vars qw(
+    $debug_mode @menulist %menus %menuhooks %menuhash
+    $frame_mode $pathinfo $script_name $script_path $s_url $selfurl
+    $menu $remote_addr $remote_host $remote_user
+    $scookie $new_cookie $server $serverid $zone $zoneid $res $bgcolor $refresh
+    $hook @names $var $menuref $arg $arg_str
+    $login_debug $login_time $login_debug_log $ticks $pwd_chk $last_from
+    $msg $date $i $u
+    %state %perms
+    $rhf_key $key
+);
+
+# configuration globals populated by load_config()
+use vars qw(
+    $SAURON_DEBUG_MODE $ALEVEL_SHOW_UNALLOCATED_CIDRS $ALEVEL_HISTORY_SEARCH
+    $SAURON_TOPMENU_BGCOLOR $SAURON_TOPMENU_FONTCOLOR
+    $SAURON_ICON_PATH $SAURON_DTD_HACK $SAURON_CHARSET
+    $SERVER_ID $SAURON_USER_TIMEOUT $SAURON_AUTH_MODE
+    $SAURON_NO_REMOTE_ADDR_AUTH $LOG_DIR $SAURON_PLUGINS $PROG_DIR
+    %SAURON_RHF $SAURON_TEMP_LOCK $SAURON_SECURE_COOKIES
+    $SAURON_AUTH_PROG
+);
 
 $CGI::DISABLE_UPLOADS = 1; # no uploads
 $CGI::POST_MAX = 100000; # max 100k posts
@@ -29,7 +53,7 @@ $0 = $PG_NAME;
 
 load_config();
 
-$SAURON_CGI_VER = ' $Revision: 1.204 $ $Date: 2005/01/27 09:24:44 $ ';
+my $SAURON_CGI_VER = ' $Revision: 1.204 $ $Date: 2005/01/27 09:24:44 $ ';
 $debug_mode = $SAURON_DEBUG_MODE;
 #$|=1;
 
@@ -430,6 +454,7 @@ exit;
 #
 sub about_menu() {
   my $sub=param('sub') // '';
+  my ($VER);
 
   if ($sub eq 'copyright') {
     open(FILE,"$PROG_DIR/COPYRIGHT") || return;
@@ -683,6 +708,7 @@ sub login_auth() {
 	}
 
 	# print news/MOTD stuff
+	my @newslist;
 	get_news_list($state{serverid},3,\@newslist);
 	if (@newslist > 0) {
 	  print h2("Message(s) of the day:"),
@@ -928,9 +954,8 @@ sub frame_2() {
 
 sub init_plugins($) {
   my($plugins) = @_;
-
   my(@plugs) = split(/,/,$plugins);
-  my($ret,$i,$file,$file2);
+  my($ALEVEL, $j, $MENU, $MENUDATA, $ret, $i, $file, $file2, $NAME);
 
   for $i (0..$#plugs) {
     $file="$PROG_DIR/plugins/$plugs[$i].conf";


### PR DESCRIPTION
### Overview
Re-enables `use strict; use warnings;` in browser.cgi and fixes associated runtime errors. 
Additionally hardens parameter handling in CGIutil.pm to eliminate CGI.pm context warnings.

### Changes

#### browser.cgi
- **Enabled strict/warnings**: Were previously commented out; now active to catch potential issues
- **Secured config lookups**: Added defensive checks before dereferencing `%BROWSER_CONF` and `%BROWSER_HELP`
  - Validates that `$key` is non-empty and sanitized
  - Ensures hash entries exist and are proper ARRAY refs with expected length
  - Returns `html_error2()` on invalid parameters instead of crashing

**Fixes errors:**
- `Can't use an undefined value as an ARRAY reference at line 167`
- `Can't use an undefined value as an ARRAY reference at line 188`

#### Sauron/CGIutil.pm
- **Wrapped param() calls in scalar context**: Prevents `CGI::param called in list context` warnings
  - Added caching of parameter values (`$cur`, `$cur_e`) before use in function arguments
  - Applied to lines ~690 and ~1376
  - Eliminates Apache error logs from CGI.pm context checks


