### PR TITLE
Fix XSS vulnerabilities in CGI utility modules

### DIFF
--- a/Sauron/CGI/Utils.pm
+++ b/Sauron/CGI/Utils.pm
@@ -13,6 +13,7 @@ use Sauron::BackEnd;
 use Sauron::Util;
 use Sauron::Sauron;
 use Sauron::SetupIO;
+use HTML::Entities;
 use strict;
 use vars qw($VERSION @ISA @EXPORT);
 use Sys::Syslog qw(:DEFAULT setlogsock);
@@ -407,7 +408,7 @@ sub edit_magic($$$$$$$) {
 
   unless (param($prefix . '_re_edit') eq '1') {
     if (&$get_func($id,\%h)) {
-      print h2("Cannot get $name record (id=$id)!");
+      print h2("Cannot get $name record (id=\"" . encode_entities($id) . "\")!");
       return -3;
     }
   }
@@ -474,7 +475,7 @@ sub delete_magic($$$$$$$) {
 
   if (param($prefix . '_confirm') ne '') {
     if(&$get_func($id,\%h) < 0) {
-      print h2("Cannot find $name record anymore! ($id)");
+      print h2("Cannot find $name record anymore! (" . encode_entities($id) . ")");
       return -2;
     }
 
@@ -491,7 +492,7 @@ sub delete_magic($$$$$$$) {
 
 
   if (&$get_func($id,\%h)) {
-    print h2("Cannot get $name record (id=$id)!");
+    print h2("Cannot get $name record (id=\"" . encode_entities($id) . "\")!");
     return -3;
   }
 

--- a/Sauron/CGIutil.pm
+++ b/Sauron/CGIutil.pm
@@ -1729,7 +1729,10 @@ sub display_list($$$)
     for $j (0..$cols) {
       $val = $$list[$i][$offset+$j];
       if ($$header[$j] =~ /Date/) {
-	$val = localtime($val)." " if ($val > 0);
+        $val = localtime($val)." " if ($val > 0);
+      }
+      if (defined $val && $val ne '' && $val !~ /<a\s/i) {
+        $val = encode_entities($val);
       }
       print td(($val ne '' ? $val : '&nbsp;'));
     }
@@ -1742,17 +1745,17 @@ sub display_list($$$)
 
 sub alert1($) {
   my($msg)=@_;
-  print "<H2><FONT color=\"red\">$msg</FONT></H2>";
+  print "<H2><FONT color=\"red\">" . encode_entities($msg) . "</FONT></H2>";
 }
 
 sub alert2($) {
   my($msg)=@_;
-  print "<H3><FONT color=\"red\">$msg</FONT></H3>";
+  print "<H3><FONT color=\"red\">" . encode_entities($msg) . "</FONT></H3>";
 }
 
 sub warning1($) {
   my($msg)=@_;
-  print "<H2><FONT color=\"orange\">$msg</FONT></H2>";
+  print "<H2><FONT color=\"orange\">" . encode_entities($msg) . "</FONT></H2>";
 }
 
 sub html_error($) {


### PR DESCRIPTION
- Add HTML::Entities encoding to alert/warning messages (alert1, alert2, warning1)
- Encode database values in display_list() table rendering to prevent stored XSS
- Encode record IDs from CGI parameters in edit_magic() and delete_magic()
- Skip encoding for existing HTML anchors to preserve expected functionality

Severity: HIGH
Fixes stored and reflected XSS via error messages, table rendering, and record management