### PR TITLE
Add RFC 2915 compliant NAPTR record support

### DIFF
--- a/Sauron/BackEnd.pm
+++ b/Sauron/BackEnd.pm
@@ -1334,6 +1334,9 @@ sub get_zone($$) {
 		      "type=2 AND ref=$hid ORDER BY pri,mx",$rec,'mx');
       get_array_field("txt_entries",3,"id,txt,comment","TXT,Comments",
 		      "type=2 AND ref=$hid ORDER BY id",$rec,'txt');
+      get_array_field("naptr_entries",8,"id,order_val,preference,flags,service,regexp,replacement,comment",
+		      "Order,Preference,Flags,Service,Regexp,Replacement,Comments",
+		      "type=1 AND ref=$hid ORDER BY order_val,preference,flags,service,regexp,replacement",$rec,'naptr');
       get_array_field("a_entries",4,"id,ip,reverse,forward",
 		      "IP,reverse,forward","host=$hid ORDER BY ip",$rec,'ip');
 
@@ -1420,6 +1423,9 @@ sub update_zone($) {
     $r=update_array_field("txt_entries",3,"txt,comment,type,ref",
 			  'txt',$rec,"2,$hid");
     if ($r < 0) { db_rollback(); return -14; }
+    $r=update_array_field("naptr_entries",7,"order_val,preference,flags,service,regexp,replacement,comment,type,ref",
+			  'naptr',$rec,"1,$hid");
+    if ($r < 0) { db_rollback(); return -140; }
   }
 
   # dhcp
@@ -1668,6 +1674,10 @@ sub add_zone($) {
     $res = add_array_field('txt_entries','txt,comment','txt',$rec,
 			   'type,ref',"2,$hid");
     if ($res < 0) { db_rollback(); return -104; }
+    # naptr
+    $res = add_array_field('naptr_entries','order_val,preference,flags,service,regexp,replacement,comment',
+			   'naptr',$rec,'type,ref',"1,$hid");
+    if ($res < 0) { db_rollback(); return -1040; }
     # ip
     $res = add_array_field('a_entries','ip,reverse,forward','ip',$rec,
 			   'host',"$hid");

--- a/Sauron/CGI/Hosts.pm
+++ b/Sauron/CGI/Hosts.pm
@@ -100,6 +100,7 @@ my %ds_digest_type=(
 );
 
 my %naptr_flags=(
+    0=>'(non-terminal)',
     1=>'S',
     2=>'A',
     3=>'U',
@@ -251,7 +252,7 @@ my %host_form = (
 
   {ftype=>0, name=>'NAPTR records', no_edit=>1, iff=>['type','14']},
   {ftype=>2, tag=>'naptr_l', name=>'NAPTR entries', fields=>7,len=>[3,3,2,5,20,20,20],
-   empty=>[0,0,0,0,0,0,1], maxlen=>[5,5,2,20,100,100,80],addempty=>[-1,-1,-1,-1,-1,-1,0],
+   empty=>[0,0,1,1,1,0,1], maxlen=>[5,5,2,20,100,100,80],addempty=>[-1,-1,-1,-1,-1,-1,0],
    elabels=>['Order','Preference','Flags','Service','Regexp','Replacement','Comment'],
    type=>['priority','priority','enum','text','text','text','text'],
    enum=>[undef, undef, \%naptr_flags, undef, undef, undef, undef],
@@ -452,7 +453,7 @@ my %new_host_form = (
    iff=>['type','12']},
 
   {ftype=>2, tag=>'naptr_l', name=>'NAPTR entries', fields=>7,len=>[5,5,5,5,5,5,20],
-   empty=>[0,0,0,0,0,0,1], maxlen=>[5,5,5,5,5,5,80],addempty=>[-1,-1,-1,-1,-1,-1,0],
+   empty=>[0,0,1,1,1,0,1], maxlen=>[5,5,5,5,5,5,80],addempty=>[-1,-1,-1,-1,-1,-1,0],
    dot=>1, # allows dot in replacement
    elabels=>['Order','Preference','Flags','Service','Regexp','Replacement','Comment'],
    type=>['priority','priority','enum','text','text','fqdn','text'],

--- a/Sauron/CGI/Zones.pm
+++ b/Sauron/CGI/Zones.pm
@@ -39,6 +39,14 @@ sub write2log{
 
 my %ztypenames=(M=>'Master',S=>'Slave',F=>'Forward',H=>'Hint');
 
+my %naptr_flags=(
+    0=>'(non-terminal)',
+    1=>'S',
+    2=>'A',
+    3=>'U',
+    4=>'P'
+);
+
 my %new_zone_form=(
  data=>[
   {ftype=>0, name=>'New zone'},
@@ -113,6 +121,12 @@ my %zone_form = (
    iff2=>['reverse','f']},
   {ftype=>2, tag=>'txt', name=>'Info (TXT)', type=>['text','text'], fields=>2,
    len=>[68,15], maxlen=>[220,15], empty=>[0,1], elabels=>['TXT','comment'], whitesp=>['P','P'],
+   iff=>['type','M'], iff2=>['reverse','f']},
+  {ftype=>2, tag=>'naptr', name=>'NAPTR entries', fields=>7, len=>[3,3,2,5,20,20,20],
+   empty=>[0,0,1,1,1,0,1], maxlen=>[5,5,2,20,100,100,80], addempty=>[-1,-1,-1,-1,-1,-1,0],
+   elabels=>['Order','Preference','Flags','Service','Regexp','Replacement','Comment'],
+   type=>['priority','priority','enum','text','text','text','text'],
+   enum=>[undef, undef, \%naptr_flags, undef, undef, undef, undef],
    iff=>['type','M'], iff2=>['reverse','f']},
 
 # New version of Custom zone file entries: Multiple textareas instead

--- a/Sauron/UtilZone.pm
+++ b/Sauron/UtilZone.pm
@@ -267,19 +267,32 @@ sub process_zonefile($$$$) {
     }
     elsif ($type eq 'NAPTR') {
       # NAPTR: order preference flags service regexp replacement
+      # RFC 2915 Section 5: NAPTR RR Format
+      # Flags can be empty (non-terminal) or one of {A,U,S,P} (terminal, case-insensitive)
+      # Service and Regexp are both optional, but at least one must be non-empty
       fatal("$filename($.): invalid NAPTR record: $fline")
       unless (
-        $line[0]=~/^\d+$/ &&                # order
-        $line[1]=~/^\d+$/ &&                # preference
-        $line[2]=~/^".*"$/ &&               # flags (quoted string)
-        $line[3]=~/^".*"$/ &&               # service (quoted string)
-        $line[4]=~/^".*"$/ &&               # regexp (quoted string)
-        $line[5]=~/^.*$/                    # replacement
+        $line[0]=~/^\d+$/ &&                # order (unsigned 16-bit)
+        $line[1]=~/^\d+$/ &&                # preference (unsigned 16-bit)
+        $line[2]=~/^"[AUSP]?"$/i &&         # flags (empty or one of AUSP, quoted, case-insensitive)
+        $line[3]=~/^".*"$/ &&               # service (quoted string, can be empty)
+        $line[4]=~/^".*"$/ &&               # regexp (quoted string, can be empty)
+        $line[5]=~/^.+$/                    # replacement (non-empty domain name)
       );
+      # Extract content for validation
+      $line[3] =~ s/^"(.*)"$/$1/; # extract service content
+      $line[4] =~ s/^"(.*)"$/$1/; # extract regexp content
+      
+      # RFC 2915: At least one of service or regexp must be non-empty (but not both empty)
+      fatal("$filename($.): NAPTR must have non-empty service or regexp (or both): $fline")
+        if ($line[3] eq '' && $line[4] eq '');
+      # RFC 2915: Replacement must be non-empty domain
+      fatal("$filename($.): NAPTR replacement cannot be empty: $fline")
+        if ($line[5] eq '');
+      
       $line[2] =~ tr/a-z/A-Z/; # flags are case-insensitive, convert to uppercase
-      $line[2] =~ s/^"(.*)"$/$1/; # remove quotes from flag
-      $line[3] =~ s/^"(.*)"$/$1/; # remove quotes from service
-      $line[4] =~ s/^"(.*)"$/$1/; # remove quotes from regexp
+      $line[2] =~ s/^"(.*)"$/$1/; # remove quotes from flag (can be empty string)
+      # service and regexp already have quotes removed above
       push @{$rec->{NAPTR}}, join(" ", @line[0..5]);
     }
     elsif ($type eq 'WKS') {

--- a/import-zone
+++ b/import-zone
@@ -123,6 +123,20 @@ unless ($pzoneid > 0) {
   $zonehash{txt}=[];
   foreach $rtmp (@{$rec->{TXT}}) { push @{$zonehash{txt}}, [0,$rtmp,'']; }
   foreach $rtmp (@{$rec->{CAA}}) { push @{$zonehash{zentries}}, [0,"@ IN CAA $rtmp",'']; }
+  $zonehash{naptr}=[];
+  if (@{$rec->{NAPTR}} > 0) {
+    print "Processing " . scalar(@{$rec->{NAPTR}}) . " NAPTR records for zone apex\n" if ($opt_verbose);
+  }
+  foreach $rtmp (@{$rec->{NAPTR}}) {
+    my @naptr_parts = split(/ /, $rtmp);
+    # NAPTR format: order preference flags service regexp replacement
+    if (@naptr_parts >= 6) {
+      push @{$zonehash{naptr}}, [0,@naptr_parts[0..5],''];
+      print "  Added NAPTR: order=$naptr_parts[0], pref=$naptr_parts[1], flags=$naptr_parts[2], service=$naptr_parts[3]\n" if ($opt_verbose);
+    } else {
+      print STDERR "Warning: Invalid NAPTR record (needs 6 parts, got " . scalar(@naptr_parts) . "): $rtmp\n";
+    }
+  }
   $zonehash{ip}=[];
   foreach $rtmp (@{$rec->{A}}) { push @{$zonehash{ip}},[0,$rtmp,'true','true']; }
   foreach $rtmp (@{$rec->{AAAA}}) { push @{$zonehash{ip}},[0,$rtmp,'true','true']; }
@@ -207,6 +221,11 @@ foreach $host (sort keys %zonedata) {
 
   fatal("empty hostname adfter stripping origin: $host") unless ($host2);
   print "host: $host ($host2) (type=$hosttype)\n" if ($opt_verbose);
+  if ($hosttype == 14 && @{$rec->{NAPTR}} > 0) {
+    for my $k (0..$#{$rec->{NAPTR}}) {
+      print "  NAPTR[$k]: $rec->{NAPTR}[$k]\n" if ($opt_verbose);
+    }
+  }
 
   $mxlist = db_build_list_str($rec->{MX});
   $mx=($mxhash{$mxlist} ? $mxhash{$mxlist} : -1);
@@ -239,7 +258,7 @@ foreach $host (sort keys %zonedata) {
   }
   undef @naptr_l;
   for $k (0..$#{$rec->{NAPTR}}) {
-    push @naptr_l, [0,split(' ', $rec->{NAPTR}->[$k]),''];
+    push @naptr_l, [0,split(/ /, $rec->{NAPTR}->[$k]),''];
   }
   undef @txt_l;
   for $k (0..$#{$rec->{TXT}}) {

--- a/sauron
+++ b/sauron
@@ -1527,7 +1527,7 @@ sub make_dns() {
          " b.order_val,b.preference,b.flags,b.service,b.regexp,b.replacement " .
          "FROM hosts a, naptr_entries b, zones z " .
          "WHERE a.zone=z.id AND z.id=$zoneid " .
-         "AND a.type=14 AND a.id=b.ref AND b.type=1 " .
+         "AND (a.type=10 OR a.type=14) AND a.id=b.ref AND b.type=1 " .
          "ORDER BY a.domain,b.order_val,b.preference;",\@q);
     error(db_errormsg()) if (db_errormsg());
     if (@q > 0) {

--- a/sql/dbconvert_1.7to1.8
+++ b/sql/dbconvert_1.7to1.8
@@ -106,19 +106,16 @@ ALTER TABLE ds_entries OWNER TO sauron;
 CREATE TABLE naptr_entries (
     id          SERIAL PRIMARY KEY, /* unique ID */
     type        INT4 NOT NULL, /* type:
-                        1=host */
+                       1=host */
     ref         INT4 NOT NULL, /* ptr to table specefied by type field
                         -->hosts.id */
     order_val   INT4 NOT NULL CHECK (order_val >= 0), /* RFC 2915: ORDER */
     preference  INT4 NOT NULL CHECK (preference >= 0), /* RFC 2915: PREFERENCE */
-    flags       CHAR(1) NOT NULL CHECK (flags ~* '^[AUSP]$'), /* value:
-                        A=A or AAAA record
-                        S=SRV record
-                        U=URI
-                        P=Protocol specific */
-    service       TEXT NOT NULL, /* service name, example: "E2U+sip" */
-    regexp        TEXT NOT NULL, /* regexp by RFC 2915 */
-    replacement   TEXT NOT NULL, /* target FQDN (can be ".") */
+    flags       CHAR(1) CHECK (flags ~ '^[AUSP]?$'), /* RFC 2915: FLAGS
+                        empty=non-terminal, A=A/AAAA, S=SRV, U=URI, P=PTR */
+    service     TEXT, /* RFC 2915: service name, can be empty if regexp is defined */
+    regexp      TEXT, /* RFC 2915: regexp - can be empty */
+    replacement TEXT NOT NULL, /* target FQDN (can be ".") */
     comment     TEXT /* comment */
 );
 

--- a/sql/naptr_entries.sql
+++ b/sql/naptr_entries.sql
@@ -12,14 +12,11 @@ CREATE TABLE naptr_entries (
                         -->hosts.id */
     order_val   INT4 NOT NULL CHECK (order_val >= 0), /* RFC 2915: ORDER */
     preference  INT4 NOT NULL CHECK (preference >= 0), /* RFC 2915: PREFERENCE */
-    flags       CHAR(1) NOT NULL CHECK (flags ~* '^[AUSP]$'), /* value:
-                        A=A or AAAA record
-                        S=SRV record
-                        U=URI
-                        P=Protocol specific */
-    service       TEXT NOT NULL, /* service name, example: "E2U+sip" */
-    regexp        TEXT NOT NULL, /* regexp by RFC 2915 */
-    replacement   TEXT NOT NULL, /* target FQDN (can be ".") */
+    flags       CHAR(1) CHECK (flags ~ '^[AUSP]?$'), /* RFC 2915: FLAGS
+                        empty=non-terminal, A=A/AAAA, S=SRV, U=URI, P=PTR */
+    service     TEXT, /* RFC 2915: service name, can be empty if regexp is defined */
+    regexp      TEXT, /* RFC 2915: regexp - can be empty */
+    replacement TEXT NOT NULL, /* target FQDN (can be ".") */
     comment     TEXT /* comment */
 );
 


### PR DESCRIPTION
Support for NAPTR records has been divided into
* records for the apex zone (managed in Zones)
* named records (managed in Hosts)

Support for empty Flags, Service, and Regexp entries has been added, including conditions of use (Service can be empty if Regexp is not empty).

The definition of the naptr_entries table has been modified.