### PR TITLE
Add catalog zone groups support (RFC 9432 §5.2)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,13 @@
 	  - New zone type 'C' (Catalog) for aggregating multiple zone metadata
 	  - Automatic zone distribution via AXFR transfers to secondary servers
 	  - Web interface for managing catalog membership
+	- Added Catalog Zone Groups support (RFC 9432 §5.2) [svamberg]
+	  - Member zones can be assigned to multiple named groups per catalog
+	  - Group definitions managed per catalog zone with optional comments
+	  - Web UI for group management with usage tracking and delete warnings
+	  - BIND zone file generator outputs group TXT records per member
+	  - New tables: zone_catalog_groups, catalog_group_defs
+	  - New "Catalog Groups" menu item and inline link from catalog zone view
 	- Added new option --keep-pending for sauron command [svamberg]
 	- Add check-reverse utility script for DNS PTR record validation [svamberg]
 	  - Verifies that A/AAAA records have corresponding PTR records in DNS

--- a/Makefile.in
+++ b/Makefile.in
@@ -82,7 +82,9 @@ SQL_TABLES =	sql/common.sql \
 		sql/vlans.sql sql/vmps.sql sql/group_entries.sql \
 		sql/keys.sql sql/acls.sql sql/leases.sql \
 		sql/sshfp_entries.sql sql/tlsa_entries.sql \
-		sql/ds_entries.sql sql/naptr_entries.sql
+		sql/ds_entries.sql sql/naptr_entries.sql \
+		sql/catalog_group_defs.sql sql/zone_catalog_groups.sql
+
 
 
 SQL_MISC =      sql/DEFAULTS.sql sql/misc.sql sql/copy_tables.sql \

--- a/Sauron/BackEnd.pm
+++ b/Sauron/BackEnd.pm
@@ -172,6 +172,13 @@ $VERSION = '$Id:$ ';
 	     get_zone_catalogs
 	     add_zone_to_catalog
 	     remove_zone_from_catalog
+
+	     get_catalog_group_defs
+	     add_catalog_group_def
+	     delete_catalog_group_def
+	     get_member_groups
+	     set_member_groups
+	     get_catalog_group_usage
 	    );
 
 # Catalog zones support (RFC 9432) - six functions exported above
@@ -1398,12 +1405,31 @@ sub get_zone($$) {
         my $zone_type = $member->[2];    # zone type (M, S, F, H, C)
         my $server_name = $member->[4];  # server name
         my $type_label = $zone_type_names{$zone_type} || $zone_type;  # Get readable type name
-        #push @member_list, "$zone_name ($type_label at $server_name)";
-        push @member_list, "$zone_name ($type_label)";
+        my $groups = $member->[7];       # groups arrayref
+        my $group_str = '';
+        if (ref($groups) eq 'ARRAY' && @{$groups}) {
+          $group_str = ' [' . join(', ', @{$groups}) . ']';
+        }
+        push @member_list, "$zone_name ($type_label)$group_str";
       }
       $rec->{catalog_members_list} = join(', ', @member_list);
     } else {
       $rec->{catalog_members_list} = 'None';
+    }
+
+    # Load group definitions for this catalog zone
+    my $rec_gdefs = {};
+    get_catalog_group_defs($id, $rec_gdefs);
+    if ($rec_gdefs->{count} > 0) {
+      my @gdef_list;
+      for my $gdef (@{$rec_gdefs->{groups}}) {
+        my $gname = $gdef->[1];
+        my $gcomment = $gdef->[2];
+        push @gdef_list, $gcomment ? "$gname ($gcomment)" : $gname;
+      }
+      $rec->{catalog_group_defs_list} = join(', ', @gdef_list);
+    } else {
+      $rec->{catalog_group_defs_list} = 'None';
     }
   } else {
     # Zone is a regular zone - load which catalogs contain it
@@ -1429,6 +1455,8 @@ sub get_zone($$) {
       get_catalog_zones_for_selection($id, $sid, $rec_sel);
       $rec->{available_catalogs} = $rec_sel->{available_catalogs};
       $rec->{catalog_zones_selected} = $rec_sel->{catalog_zones_selected};
+      $rec->{catalog_group_defs} = $rec_sel->{catalog_group_defs};
+      $rec->{member_groups} = $rec_sel->{member_groups};
     }
   }
 
@@ -1449,6 +1477,7 @@ sub update_zone($) {
 
   # Catalog zones support - save before cleanup
   my $selected_catalogs = $rec->{catalog_zones_selected} || [];
+  my $selected_member_groups = $rec->{member_groups} || {};
 
   # Catalog zones support - clean up before update
   delete $rec->{catalog_members};
@@ -1460,6 +1489,10 @@ sub update_zone($) {
   delete $rec->{available_catalogs};
   delete $rec->{catalog_zones_selected};
   delete $rec->{catalog_zones_selected_links};
+  delete $rec->{catalog_group_defs};
+  delete $rec->{catalog_group_defs_list};
+  delete $rec->{catalog_group_manage_link};
+  delete $rec->{member_groups};
 
   $rec->{flags}=0;
   $rec->{flags}|=0x01 if ($rec->{txt_auto_generation});
@@ -1625,6 +1658,19 @@ sub update_zone($) {
         if ($r < 0 && $r != -10) { db_rollback(); return -24; }  # -10 means already exists, which is ok
       }
     }
+
+    # Update group assignments for each selected catalog
+    if (ref($selected_member_groups) eq 'HASH') {
+      for my $cat_id (@new_catalogs) {
+        my $groups = $selected_member_groups->{$cat_id} || [];
+        $r = set_member_groups($id, $cat_id, $groups);
+        if ($r < 0) {
+          write2log("ERROR: Failed to set groups for zone $id in catalog $cat_id: $r");
+          db_rollback();
+          return -26;
+        }
+      }
+    }
   }
 
   return db_commit();
@@ -1732,6 +1778,21 @@ sub _delete_zone_parts($) {
                  "SELECT a.id FROM group_entries a, hosts h " .
                  "WHERE h.zone=$id AND a.host=h.id)");
     if ($res < 0) { return -20; }
+
+    # zone_catalog_groups (must be deleted before zone_catalogs due to FK)
+    $res=db_exec("DELETE FROM zone_catalog_groups WHERE zone_catalog_id IN (" .
+                 "SELECT id FROM zone_catalogs " .
+                 "WHERE catalog_zone_id=$id OR member_zone_id=$id)");
+    if ($res < 0) { return -21; }
+
+    # catalog_group_defs (for catalog zones)
+    $res=db_exec("DELETE FROM catalog_group_defs WHERE catalog_zone_id=$id");
+    if ($res < 0) { return -22; }
+
+    # zone_catalogs
+    $res=db_exec("DELETE FROM zone_catalogs " .
+                 "WHERE catalog_zone_id=$id OR member_zone_id=$id");
+    if ($res < 0) { return -23; }
 
     # hosts
     $res=db_exec("DELETE FROM hosts WHERE zone=$id");
@@ -4489,18 +4550,30 @@ sub validate_zone_for_catalog($$) {
 
 sub get_zone_catalog_members($$) {
   my($catalog_zone_id, $rec) = @_;
-  my(@q, $i);
+  my(@q, @g, $i);
 
   return -1 unless ($catalog_zone_id > 0);
 
   $rec = {} unless (ref($rec) eq 'HASH');
 
-  db_query("SELECT zc.member_zone_id, z.name, z.type, z.server, s.name, zc.version " .
+  db_query("SELECT zc.member_zone_id, z.name, z.type, z.server, s.name, " .
+           "zc.version, zc.id " .
            "FROM zone_catalogs zc " .
            "JOIN zones z ON zc.member_zone_id = z.id " .
            "JOIN servers s ON z.server = s.id " .
            "WHERE zc.catalog_zone_id = $catalog_zone_id " .
            "ORDER BY z.name", \@q);
+
+  # Load groups for each membership
+  for $i (0 .. $#q) {
+    my $membership_id = $q[$i][6];
+    my @member_groups;
+    db_query("SELECT group_name FROM zone_catalog_groups " .
+             "WHERE zone_catalog_id = $membership_id " .
+             "ORDER BY group_name", \@g);
+    @member_groups = map { $_->[0] } @g;
+    $q[$i][7] = \@member_groups;  # groups as arrayref at index 7
+  }
 
   $rec->{count} = @q;
   $rec->{members} = \@q;
@@ -4510,17 +4583,28 @@ sub get_zone_catalog_members($$) {
 
 sub get_zone_catalogs($$) {
   my($zone_id, $rec) = @_;
-  my(@q, $i);
+  my(@q, @g, $i);
 
   return -1 unless ($zone_id > 0);
 
   $rec = {} unless (ref($rec) eq 'HASH');
 
-  db_query("SELECT zc.catalog_zone_id, z.name, z.server, zc.version " .
+  db_query("SELECT zc.catalog_zone_id, z.name, z.server, zc.version, zc.id " .
            "FROM zone_catalogs zc " .
            "JOIN zones z ON zc.catalog_zone_id = z.id " .
            "WHERE zc.member_zone_id = $zone_id " .
            "ORDER BY z.name", \@q);
+
+  # Load groups for each membership
+  for $i (0 .. $#q) {
+    my $membership_id = $q[$i][4];
+    my @member_groups;
+    db_query("SELECT group_name FROM zone_catalog_groups " .
+             "WHERE zone_catalog_id = $membership_id " .
+             "ORDER BY group_name", \@g);
+    @member_groups = map { $_->[0] } @g;
+    $q[$i][5] = \@member_groups;  # groups as arrayref at index 5
+  }
 
   $rec->{count} = @q;
   $rec->{catalogs} = \@q;
@@ -4543,20 +4627,37 @@ sub get_catalog_zones_for_selection($$$) {
 
   # Build list for form display (ftype 14)
   my @catalog_list;
+  my %catalog_group_defs;
   for my $zone_row (@available) {
     push @catalog_list, [$zone_row->[0], $zone_row->[1], $zone_row->[2]];
+
+    # Load group definitions for each catalog zone
+    my @gdefs;
+    db_query("SELECT id, group_name, comment FROM catalog_group_defs " .
+             "WHERE catalog_zone_id = $zone_row->[0] " .
+             "ORDER BY group_name", \@gdefs);
+    $catalog_group_defs{$zone_row->[0]} = \@gdefs;
   }
   $rec->{available_catalogs} = \@catalog_list;
+  $rec->{catalog_group_defs} = \%catalog_group_defs;
 
   # Get currently selected catalogs for this zone (if zone_id is valid)
   if ($zone_id > 0) {
-    db_query("SELECT catalog_zone_id FROM zone_catalogs " .
+    db_query("SELECT catalog_zone_id, id FROM zone_catalogs " .
              "WHERE member_zone_id = $zone_id " .
              "ORDER BY catalog_zone_id", \@selected);
 
-    # Create a hash of selected IDs
+    # Create a hash of selected IDs and load their groups
+    my %member_groups;
     for my $sel_row (@selected) {
       $selected_ids{$sel_row->[0]} = 1;
+
+      # Load assigned groups for this membership
+      my @grps;
+      db_query("SELECT group_name FROM zone_catalog_groups " .
+               "WHERE zone_catalog_id = $sel_row->[1] " .
+               "ORDER BY group_name", \@grps);
+      $member_groups{$sel_row->[0]} = [ map { $_->[0] } @grps ];
     }
 
     # Build selected array for form
@@ -4567,8 +4668,10 @@ sub get_catalog_zones_for_selection($$$) {
       }
     }
     $rec->{catalog_zones_selected} = \@selected_cat_ids;
+    $rec->{member_groups} = \%member_groups;
   } else {
     $rec->{catalog_zones_selected} = [];
+    $rec->{member_groups} = {};
   }
 
   return 0;
@@ -4617,6 +4720,194 @@ sub remove_zone_from_catalog($$) {
                  "WHERE catalog_zone_id=$catalog_zone_id AND member_zone_id=$zone_id");
 
   return $res;
+}
+
+
+# get_catalog_group_defs($catalog_zone_id, $rec)
+# Returns predefined group definitions for a catalog zone.
+# rec->{groups} = [[id, group_name, comment], ...]
+# rec->{count} = number of groups
+sub get_catalog_group_defs($$) {
+  my($catalog_zone_id, $rec) = @_;
+  my(@q);
+
+  return -1 unless ($catalog_zone_id > 0);
+
+  $rec = {} unless (ref($rec) eq 'HASH');
+
+  db_query("SELECT id, group_name, comment FROM catalog_group_defs " .
+           "WHERE catalog_zone_id = $catalog_zone_id " .
+           "ORDER BY group_name", \@q);
+
+  $rec->{count} = scalar @q;
+  $rec->{groups} = \@q;
+
+  return 0;
+}
+
+# add_catalog_group_def($catalog_zone_id, $group_name, $comment)
+# Adds a new group definition to a catalog zone.
+# Returns: 0 on success, negative on error
+sub add_catalog_group_def($$$) {
+  my($catalog_zone_id, $group_name, $comment) = @_;
+  my($res, @q);
+
+  return -1 unless ($catalog_zone_id > 0);
+  return -2 unless (defined($group_name) && $group_name ne '');
+
+  # Verify this is a catalog zone
+  $res = is_catalog_zone($catalog_zone_id);
+  return -3 unless ($res == 1);
+
+  # Check if group already exists
+  db_query("SELECT id FROM catalog_group_defs " .
+           "WHERE catalog_zone_id=$catalog_zone_id AND group_name=" .
+           db_encode_str($group_name), \@q);
+  return -10 if (@q > 0);  # Already exists
+
+  my $comment_sql = defined($comment) && $comment ne ''
+                    ? db_encode_str($comment) : 'NULL';
+
+  $res = db_exec("INSERT INTO catalog_group_defs " .
+                 "(catalog_zone_id, group_name, comment) VALUES(" .
+                 "$catalog_zone_id, " . db_encode_str($group_name) .
+                 ", $comment_sql)");
+
+  if ($res < 0) {
+    write2log("ERROR: Failed to add group def '$group_name' to catalog $catalog_zone_id: $res");
+  }
+
+  return $res;
+}
+
+# delete_catalog_group_def($catalog_zone_id, $group_name)
+# Removes a group definition from a catalog zone.
+# Also removes all group assignments using this name within the catalog.
+# Returns: 0 on success, negative on error
+sub delete_catalog_group_def($$) {
+  my($catalog_zone_id, $group_name) = @_;
+  my($res);
+
+  return -1 unless ($catalog_zone_id > 0);
+  return -2 unless (defined($group_name) && $group_name ne '');
+
+  # Delete group assignments that reference this group within this catalog
+  $res = db_exec("DELETE FROM zone_catalog_groups WHERE id IN (" .
+                 "SELECT zcg.id FROM zone_catalog_groups zcg " .
+                 "JOIN zone_catalogs zc ON zcg.zone_catalog_id = zc.id " .
+                 "WHERE zc.catalog_zone_id = $catalog_zone_id " .
+                 "AND zcg.group_name = " . db_encode_str($group_name) . ")");
+  return $res if ($res < 0);
+
+  # Delete the group definition
+  $res = db_exec("DELETE FROM catalog_group_defs " .
+                 "WHERE catalog_zone_id=$catalog_zone_id AND group_name=" .
+                 db_encode_str($group_name));
+
+  return $res;
+}
+
+# get_member_groups($zone_id, $catalog_zone_id, $rec)
+# Returns groups assigned to a member zone within a specific catalog.
+# rec->{groups} = ['group1', 'group2', ...]
+sub get_member_groups($$$) {
+  my($zone_id, $catalog_zone_id, $rec) = @_;
+  my(@q, @g);
+
+  return -1 unless ($zone_id > 0 && $catalog_zone_id > 0);
+
+  $rec = {} unless (ref($rec) eq 'HASH');
+
+  # Get the membership ID
+  db_query("SELECT id FROM zone_catalogs " .
+           "WHERE catalog_zone_id=$catalog_zone_id AND member_zone_id=$zone_id", \@q);
+  return -2 unless (@q > 0);
+
+  my $membership_id = $q[0][0];
+
+  db_query("SELECT group_name FROM zone_catalog_groups " .
+           "WHERE zone_catalog_id = $membership_id " .
+           "ORDER BY group_name", \@g);
+
+  $rec->{groups} = [ map { $_->[0] } @g ];
+
+  return 0;
+}
+
+# set_member_groups($zone_id, $catalog_zone_id, \@groups)
+# Sets the groups for a member zone within a specific catalog.
+# Performs diff: adds new groups, removes deselected groups.
+# Returns: 0 on success, negative on error
+sub set_member_groups($$$) {
+  my($zone_id, $catalog_zone_id, $new_groups) = @_;
+  my($res, @q, @g);
+
+  return -1 unless ($zone_id > 0 && $catalog_zone_id > 0);
+
+  # Get the membership ID
+  db_query("SELECT id FROM zone_catalogs " .
+           "WHERE catalog_zone_id=$catalog_zone_id AND member_zone_id=$zone_id", \@q);
+  return -2 unless (@q > 0);
+
+  my $membership_id = $q[0][0];
+
+  # Get current groups
+  db_query("SELECT group_name FROM zone_catalog_groups " .
+           "WHERE zone_catalog_id = $membership_id", \@g);
+  my %current = map { $_->[0] => 1 } @g;
+
+  # Build new groups hash
+  my @new = ref($new_groups) eq 'ARRAY' ? @{$new_groups} : ();
+  my %new_hash = map { $_ => 1 } @new;
+
+  # Remove groups no longer selected
+  for my $gname (keys %current) {
+    unless ($new_hash{$gname}) {
+      $res = db_exec("DELETE FROM zone_catalog_groups " .
+                     "WHERE zone_catalog_id=$membership_id AND group_name=" .
+                     db_encode_str($gname));
+      return $res if ($res < 0);
+    }
+  }
+
+  # Add newly selected groups
+  for my $gname (@new) {
+    unless ($current{$gname}) {
+      $res = db_exec("INSERT INTO zone_catalog_groups " .
+                     "(zone_catalog_id, group_name) VALUES(" .
+                     "$membership_id, " . db_encode_str($gname) . ")");
+      return $res if ($res < 0);
+    }
+  }
+
+  return 0;
+}
+
+# get_catalog_group_usage($catalog_zone_id, $group_name, $rec)
+# Returns list of member zones that use a specific group within a catalog.
+# rec->{zones} = [[zone_id, zone_name, zone_type], ...]
+# rec->{count} = number of zones using this group
+sub get_catalog_group_usage($$$) {
+  my($catalog_zone_id, $group_name, $rec) = @_;
+  my(@q);
+
+  return -1 unless ($catalog_zone_id > 0);
+  return -2 unless (defined($group_name) && $group_name ne '');
+
+  $rec = {} unless (ref($rec) eq 'HASH');
+
+  db_query("SELECT z.id, z.name, z.type " .
+           "FROM zone_catalog_groups zcg " .
+           "JOIN zone_catalogs zc ON zcg.zone_catalog_id = zc.id " .
+           "JOIN zones z ON zc.member_zone_id = z.id " .
+           "WHERE zc.catalog_zone_id = $catalog_zone_id " .
+           "AND zcg.group_name = " . db_encode_str($group_name) . " " .
+           "ORDER BY z.name", \@q);
+
+  $rec->{count} = scalar @q;
+  $rec->{zones} = \@q;
+
+  return 0;
 }
 
 1;

--- a/Sauron/CGI/Zones.pm
+++ b/Sauron/CGI/Zones.pm
@@ -180,11 +180,17 @@ my %zone_form = (
    no_edit=>1, iff=>['type','C']},
   {ftype=>4, tag=>'catalog_members_list', name=>'Member zones',
    no_edit=>1, iff=>['type','C']},
+  {ftype=>4, tag=>'catalog_group_defs_list', name=>'Defined groups',
+   no_edit=>1, iff=>['type','C']},
+  {ftype=>4, tag=>'catalog_group_manage_link', name=>'Manage groups',
+   no_edit=>1, iff=>['type','C']},
   {ftype=>4, tag=>'zone_catalog_count', name=>'Number of catalogs',
    no_edit=>1, iff=>['type','M']},
 #  {ftype=>4, tag=>'zone_catalogs_list', name=>'Included in catalogs',
 #   no_edit=>1, iff=>['type','M']}, # duplicity
   {ftype=>14, tag=>'catalog_zones_selected', name=>'Member of catalog zones',
+   iff=>['type','M']},
+  {ftype=>15, tag=>'member_groups', name=>'Catalog zone groups (RFC 9432)',
    iff=>['type','M']},
 
   {ftype=>0, name=>'DHCP', iff=>['type','M']},
@@ -228,6 +234,9 @@ sub update_zone_wrapper($) {
   delete $rec->{zone_catalogs_list};
   delete $rec->{available_catalogs};
   delete $rec->{catalog_zones_selected_links};
+  delete $rec->{catalog_group_defs};
+  delete $rec->{catalog_group_defs_list};
+  delete $rec->{catalog_group_manage_link};
   delete $rec->{cdate_str};
   delete $rec->{mdate_str};
   delete $rec->{pending_info};
@@ -409,11 +418,21 @@ sub display_zone($$)
         my $zone_type = $member->[2];    # zone type
         my $server_name = $member->[4];  # server name
         my $type_label = $zone_type_names{$zone_type} || $zone_type;
-        #my $member_link = "<a href=\"$selfurl?menu=zones&selected_zone=$zone_name\" title=\"Select zone $zone_name\">$zone_name</a> ($type_label at $server_name)";
-        my $member_link = "<a href=\"$selfurl?menu=zones&selected_zone=$zone_name\" title=\"Select $type_label zone $zone_name\">$zone_name</a>";
+        my $groups = $member->[7];       # groups arrayref
+        my $group_str = '';
+        if (ref($groups) eq 'ARRAY' && @{$groups}) {
+          $group_str = ' [' . join(', ', @{$groups}) . ']';
+        }
+        my $member_link = "<a href=\"$selfurl?menu=zones&selected_zone=$zone_name\" title=\"Select $type_label zone $zone_name\">$zone_name</a>$group_str";
         push @member_links, $member_link;
       }
       $data{catalog_members_list} = join(', ', @member_links);
+    }
+
+    # Add manage groups link for catalog zones
+    if ($data{type} && $data{type} eq 'C') {
+      $data{catalog_group_manage_link} =
+        "<a href=\"$selfurl?menu=zones&sub=CatalogGroups\"><B>[ Manage Groups ]</B></a>";
     }
 
     # Format catalog zones selected list with links (for Member of catalog zones field)
@@ -655,6 +674,170 @@ sub menu_handler {
     }
     display_list(['#','Hostname','Type','Action','Date','By'],\@plist,0);
     print "<br>";
+    return;
+  }
+  elsif ($sub eq 'CatalogGroups') {
+    return if (check_perms('superuser',''));
+
+    if ($zoneid < 1) {
+      print h2("No zone selected!");
+      select_zone($state,$perms);
+      return;
+    }
+
+    # Verify this is a catalog zone
+    my $is_cat = is_catalog_zone($zoneid);
+    if ($is_cat != 1) {
+      print h2("Selected zone is not a catalog zone."),
+            p,"Only catalog zones (type C) can have group definitions.",
+            p,"<a href=\"$selfurl?menu=zones&sub=select\">Select a zone</a>";
+      return;
+    }
+
+    my $zone_name = $zone || $state->{zone} || '';
+
+    # Handle form actions
+    my $action = param('grp_action') || '';
+
+    # Add group
+    if ($action eq 'add') {
+      my $new_name = param('grp_new_name') || '';
+      my $new_comment = param('grp_new_comment') || '';
+      $new_name =~ s/^\s+|\s+$//g;
+      $new_comment =~ s/^\s+|\s+$//g;
+
+      if ($new_name eq '') {
+        print "<FONT color=\"red\">",h3("Group name cannot be empty!"),"</FONT>";
+      } elsif ($new_name =~ /[^a-zA-Z0-9_\-.]/) {
+        print "<FONT color=\"red\">",h3("Group name can only contain letters, digits, hyphens, dots and underscores!"),"</FONT>";
+      } else {
+        $res = add_catalog_group_def($zoneid, $new_name, $new_comment);
+        if ($res == -10) {
+          print "<FONT color=\"red\">",h3("Group '$new_name' already exists!"),"</FONT>";
+        } elsif ($res < 0) {
+          print "<FONT color=\"red\">",h3("Failed to add group (error: $res)"),"</FONT>";
+        } else {
+          print h3("Group '<B>$new_name</B>' added successfully.");
+        }
+      }
+    }
+
+    # Confirm delete
+    if ($action eq 'confirm_delete') {
+      my $del_name = param('grp_del_name') || '';
+      $del_name =~ s/^\s+|\s+$//g;
+
+      if ($del_name ne '') {
+        $res = delete_catalog_group_def($zoneid, $del_name);
+        if ($res < 0) {
+          print "<FONT color=\"red\">",h3("Failed to delete group (error: $res)"),"</FONT>";
+        } else {
+          print h3("Group '<B>$del_name</B>' deleted.");
+        }
+      }
+    }
+
+    # Delete check - show usage warning before actual deletion
+    if ($action eq 'delete') {
+      my $del_name = param('grp_del_name') || '';
+      $del_name =~ s/^\s+|\s+$//g;
+
+      if ($del_name ne '') {
+        my %usage;
+        get_catalog_group_usage($zoneid, $del_name, \%usage);
+
+        print h2("Delete group: $del_name"),
+              start_form(-method=>'POST',-action=>$selfurl),
+              hidden('menu','zones'),hidden('sub','CatalogGroups');
+
+        if ($usage{count} > 0) {
+          print "<FONT color=\"red\"><B>Warning:</B> This group is currently assigned to $usage{count} zone(s):</FONT>",
+                "<UL>";
+          my %zone_type_names = (M=>'master', S=>'slave', F=>'forward', H=>'hint');
+          for my $zu (@{$usage{zones}}) {
+            my $zu_name = $zu->[1];
+            my $zu_type = $zone_type_names{$zu->[2]} || $zu->[2];
+            print "<LI><a href=\"$selfurl?menu=zones&selected_zone=$zu_name\">$zu_name</a> ($zu_type)</LI>";
+          }
+          print "</UL>",
+                "<P>Deleting this group will <B>remove it from all these zones</B>.</P>";
+        } else {
+          print p,"This group is not assigned to any zone.";
+        }
+
+        print hidden('grp_action','confirm_delete'),
+              hidden('grp_del_name',$del_name),
+              submit(-name=>'grp_confirm_del',-value=>'Confirm Delete')," ",
+              submit(-name=>'grp_cancel_del',-value=>'Cancel'),
+              end_form;
+        return;
+      }
+    }
+
+    # Main display: list existing groups + add form
+    print h2("Catalog Zone Groups: $zone_name");
+
+    # Load current group definitions
+    my %gdefs;
+    get_catalog_group_defs($zoneid, \%gdefs);
+
+    # Display existing groups as a table
+    print "<TABLE width=\"80%\" bgcolor=\"white\" border=0>",
+          "<TR bgcolor=\"#aaaaff\">",th(['#','Group Name','Comment','Usage','Actions']),"</TR>";
+
+    if ($gdefs{count} > 0) {
+      my $ord = 1;
+      for my $gdef (@{$gdefs{groups}}) {
+        my $gid = $gdef->[0];
+        my $gname = $gdef->[1];
+        my $gcomment = $gdef->[2] || '&nbsp;';
+
+        # Check usage count
+        my %usage;
+        get_catalog_group_usage($zoneid, $gname, \%usage);
+        my $usage_str = $usage{count} > 0
+            ? "<FONT color=\"#cc6600\">$usage{count} zone(s)</FONT>"
+            : "<FONT color=\"green\">unused</FONT>";
+
+        # Delete button in a mini-form
+        my $del_form = "<FORM method=POST action=\"$selfurl\" style=\"display:inline\">" .
+                       "<INPUT type=hidden name=menu value=zones>" .
+                       "<INPUT type=hidden name=sub value=CatalogGroups>" .
+                       "<INPUT type=hidden name=grp_action value=delete>" .
+                       "<INPUT type=hidden name=grp_del_name value=\"" . encode_entities($gname) . "\">" .
+                       "<INPUT type=submit value=Delete></FORM>";
+
+        print "<TR bgcolor=\"#f0f0f0\">",
+              td([$ord, "<B>$gname</B>", $gcomment, $usage_str, $del_form]),
+              "</TR>";
+        $ord++;
+      }
+    } else {
+      print "<TR><TD colspan=5 align=center><I>No groups defined for this catalog zone.</I></TD></TR>";
+    }
+    print "</TABLE><BR>";
+
+    # Add group form
+    print h3("Add New Group"),
+          start_form(-method=>'POST',-action=>$selfurl),
+          hidden('menu','zones'),hidden('sub','CatalogGroups'),
+          hidden('grp_action','add'),
+          "<TABLE>",
+          "<TR><TD>Group name:</TD><TD>",
+          textfield(-name=>'grp_new_name',-size=>30,-maxlength=>63),
+          "</TD></TR>",
+          "<TR><TD>Comment:</TD><TD>",
+          textfield(-name=>'grp_new_comment',-size=>50,-maxlength=>200),
+          "</TD></TR>",
+          "<TR><TD></TD><TD>",
+          submit(-name=>'grp_add_submit',-value=>'Add Group'),
+          "</TD></TR>",
+          "</TABLE>",
+          end_form;
+
+    # Link back to zone display
+    print "<BR><a href=\"$selfurl?menu=zones&selected_zone=$zone_name\">&laquo; Back to zone $zone_name</a>";
+
     return;
   }
   elsif ($sub eq 'AddDefaults') {

--- a/Sauron/CGIutil.pm
+++ b/Sauron/CGIutil.pm
@@ -465,7 +465,7 @@ sub form_check_form($$$) {
 
 # Remove unnecessary whitespace from individual input fields.
     if (!($type == 2 || $type==5 || $type==11 || $type==12 || $type == 13 ||
-          $type == 14 || ($type==8 && $rec->{arec}))) {
+          $type == 14 || $type == 15 || ($type==8 && $rec->{arec}))) {
 	$val = remove_whitespace($val, $rec->{whitesp});
 	param($p, $val);
     }
@@ -671,6 +671,23 @@ sub form_check_form($$$) {
       }
       $data->{$tag} = \@selected;  # Store as array reference
     }
+    elsif ($type == 15) { # Catalog group checkboxes (check input)
+      # Collect selected groups per catalog zone
+      my %member_groups;
+      my $cat_count = param($p."_catcount") || 0;
+      for my $ci (0..$cat_count-1) {
+        my $cat_id = param($p."_cat_".$ci);
+        next unless (defined $cat_id && $cat_id > 0);
+        my $grp_count = param($p."_cat_".$ci."_grpcount") || 0;
+        my @groups;
+        for my $gi (0..$grp_count-1) {
+          my $gval = param($p."_cat_".$ci."_grp_".$gi);
+          push @groups, $gval if (defined $gval && $gval ne '');
+        }
+        $member_groups{$cat_id} = \@groups if @groups;
+      }
+      $data->{$tag} = \%member_groups;
+    }
   }
   return 0;
 }
@@ -838,6 +855,24 @@ sub form_magic($$$) {
 
 	# Count should be the total number of AVAILABLE items, not selected
 	param($p1."_count", scalar(@{$available}));
+      }
+      elsif ($rec->{ftype} == 15) {
+	# Catalog group checkboxes (ftype 15) - init params
+	my $available = $data->{available_catalogs} || [];
+	my $group_defs = $data->{catalog_group_defs} || {};
+	my $member_groups = $data->{$rec->{tag}} || {};
+	param($p1."_catcount", scalar(@{$available}));
+	for my $ci (0..$#{$available}) {
+	  my $cat_id = $$available[$ci][0];
+	  param($p1."_cat_".$ci, $cat_id);
+	  my $gdefs = $group_defs->{$cat_id} || [];
+	  param($p1."_cat_".$ci."_grpcount", scalar(@{$gdefs}));
+	  my %sel = map { $_ => 1 } @{$member_groups->{$cat_id} || []};
+	  for my $gi (0..$#{$gdefs}) {
+	    my $gname = $gdefs->[$gi][1];
+	    param($p1."_cat_".$ci."_grp_".$gi, $sel{$gname} ? $gname : '');
+	  }
+	}
       }
       else {
 	error("internal error (form_magic):". $rec->{ftype});
@@ -1426,6 +1461,66 @@ sub form_magic($$$) {
       print "</TR>" if ($col_count > 0);
       print "</TABLE></TD>";
     }
+    elsif ($rec->{ftype} == 15) { # Catalog group checkboxes (edit)
+      print td($rec->{name}), "<TD><TABLE>";
+      my $available = $data->{'available_catalogs'} || [];
+      my $group_defs = $data->{'catalog_group_defs'} || {};
+      my $member_groups = $data->{$rec->{tag}} || {};
+      my $selected_cats = $data->{'catalog_zones_selected'} || [];
+      my %sel_cats = map { $_ => 1 } @{$selected_cats};
+
+      # Reload from params if re-editing
+      my $cat_count_p = param($p1."_catcount");
+      my %param_groups;
+      if (defined $cat_count_p && $cat_count_p > 0) {
+	%sel_cats = ();
+	# Re-read selected catalogs from ftype 14 params
+	my $f14_count = param($rec->{tag}."_count") || param("catalog_zones_selected_count") || 0;
+	# We just show groups for catalogs that have group defs defined
+      }
+
+      print hidden(-name=>$p1."_catcount",-value=>scalar(@{$available}));
+
+      for my $ci (0..$#{$available}) {
+	my $cat_id = $$available[$ci][0];
+	my $cat_name = $$available[$ci][1];
+	my $gdefs = $group_defs->{$cat_id} || [];
+	next unless (@{$gdefs} > 0);  # Skip catalogs without group defs
+
+	print "<TR><TD colspan=2><B>$cat_name:</B></TD></TR>";
+	print hidden(-name=>$p1."_cat_".$ci,-value=>$cat_id);
+	print hidden(-name=>$p1."_cat_".$ci."_grpcount",-value=>scalar(@{$gdefs}));
+
+	# Get currently selected groups for this catalog
+	my %grp_sel;
+	# First try from re-edit params
+	my $grp_count_p = param($p1."_cat_".$ci."_grpcount");
+	if (defined $grp_count_p && $grp_count_p > 0) {
+	  for my $gi (0..$grp_count_p-1) {
+	    my $gval = param($p1."_cat_".$ci."_grp_".$gi);
+	    $grp_sel{$gval} = 1 if (defined $gval && $gval ne '');
+	  }
+	} else {
+	  # Use data from backend
+	  if (ref($member_groups) eq 'HASH' && $member_groups->{$cat_id}) {
+	    %grp_sel = map { $_ => 1 } @{$member_groups->{$cat_id}};
+	  }
+	}
+
+	print "<TR>";
+	for my $gi (0..$#{$gdefs}) {
+	  my $gname = $gdefs->[$gi][1];
+	  my $gcomment = $gdefs->[$gi][2] || '';
+	  my $label = $gcomment ? "$gname ($gcomment)" : $gname;
+	  my $is_checked = $grp_sel{$gname} ? 'on' : '';
+	  print "<TD>", checkbox(-label=>$label,
+				 -name=>$p1."_cat_".$ci."_grp_".$gi,
+				 -value=>$gname, -checked=>$is_checked), "</TD>";
+	}
+	print "</TR>";
+      }
+      print "</TABLE></TD>";
+    }
     elsif ($rec->{ftype} == 101) {
       undef @q; undef @lst; undef %lsth;
       $maxlen=$rec->{len};
@@ -1745,6 +1840,33 @@ sub display_form($$) {
         } else {
           print "<TD><FONT color='blue'>None selected</FONT></TD>";
         }
+      }
+    } elsif ($rec->{ftype} == 15) { # Catalog group checkboxes (show)
+      print td($rec->{name});
+      my $member_groups = $data->{$rec->{tag}} || {};
+      my $available = $data->{'available_catalogs'} || [];
+      my $group_defs = $data->{'catalog_group_defs'} || {};
+
+      if (ref($member_groups) eq 'HASH' && %{$member_groups}) {
+        my @parts;
+        # Build id-to-name mapping
+        my %cat_names;
+        for my $cat (@{$available}) {
+          $cat_names{$cat->[0]} = $cat->[1];
+        }
+        for my $cat_id (sort { ($cat_names{$a} || '') cmp ($cat_names{$b} || '') }
+                        keys %{$member_groups}) {
+          my $cat_name = $cat_names{$cat_id} || "catalog#$cat_id";
+          my @grps = @{$member_groups->{$cat_id}};
+          push @parts, "<B>$cat_name:</B> " . join(', ', sort @grps) if @grps;
+        }
+        if (@parts) {
+          print "<TD>" . join('<BR>', @parts) . "</TD>";
+        } else {
+          print "<TD><FONT color='blue'>No groups assigned</FONT></TD>";
+        }
+      } else {
+        print "<TD><FONT color='blue'>No groups assigned</FONT></TD>";
       }
     } else {
       error("internal error (display_form)");

--- a/cgi/sauron.cgi
+++ b/cgi/sauron.cgi
@@ -104,6 +104,7 @@ $debug_mode = $SAURON_DEBUG_MODE;
 		      ['Delete','sub=Delete','root'],
 		      ['Edit','sub=Edit','root'],
 		      [],
+		      ['Catalog Groups','sub=CatalogGroups','root'],
 		      ['Add Default Zones','sub=AddDefaults','root']
 		     ],
 	    'nets'=>[

--- a/createtables
+++ b/createtables
@@ -40,6 +40,7 @@ load_config();
 		sql/hinfo_hw.sql sql/hinfo_sw.sql
 		sql/sshfp_entries.sql sql/tlsa_entries.sql sql/ds_entries.sql
 		sql/naptr_entries.sql
+		sql/zone_catalog_groups.sql sql/catalog_group_defs.sql
 		@;
 
 

--- a/sauron
+++ b/sauron
@@ -1680,10 +1680,19 @@ sub make_dns() {
         for $i (0 .. $#{$catalog_rec->{members}}) {
           my $member_zone = $catalog_rec->{members}[$i][1];
           my $member_id = $catalog_rec->{members}[$i][0];
+          my $member_groups = $catalog_rec->{members}[$i][7];
           $member_zone =~ s/\.$//;  # Remove trailing dot
 
           printf ZONEFILE $ZFORMAT, "uuid-$member_id.zones.catalog",$ttl,'IN','PTR',"$member_zone."
             if ($bind_conf);
+
+          # Group property TXT records (RFC 9432 §5.2)
+          if ($bind_conf && ref($member_groups) eq 'ARRAY') {
+            for my $grp (@{$member_groups}) {
+              printf ZONEFILE $ZFORMAT, "group.uuid-$member_id.zones.catalog",
+                  $ttl,'IN','TXT',"\"$grp\"";
+            }
+          }
         }
       } else {
         print ZONEFILE ";\n; Catalog zone (no members currently)\n;\n" if ($bind_conf);

--- a/sql/catalog_group_defs.sql
+++ b/sql/catalog_group_defs.sql
@@ -1,0 +1,29 @@
+/* catalog_group_defs table creation
+ *
+ * table to store predefined group definitions for catalog zones
+ * Allows administrators to define available groups per catalog zone
+ * that can then be selected when assigning member zones.
+ *
+ * $Id:$
+ */
+
+/** This table stores predefined group definitions for catalog zones. **/
+
+CREATE TABLE catalog_group_defs (
+       id              SERIAL PRIMARY KEY,    /* unique ID */
+       catalog_zone_id INT4 NOT NULL,         /* ptr to zones table - the catalog
+                                                -->zones.id */
+       group_name      TEXT NOT NULL CHECK(group_name <> ''),
+                                              /* group name */
+       comment         TEXT,                  /* description of the group */
+
+       /* Constraints */
+       CONSTRAINT catalog_group_defs_fk FOREIGN KEY (catalog_zone_id)
+           REFERENCES zones(id) ON DELETE CASCADE,
+       CONSTRAINT catalog_group_defs_unique
+           UNIQUE (catalog_zone_id, group_name)
+);
+
+/* Indexes for fast lookups */
+CREATE INDEX idx_catalog_group_defs_catalog ON catalog_group_defs(catalog_zone_id);
+

--- a/sql/dbconvert_1.7to1.8
+++ b/sql/dbconvert_1.7to1.8
@@ -151,6 +151,52 @@ CREATE INDEX idx_zone_catalogs_member ON zone_catalogs(member_zone_id);
 
 ALTER TABLE zone_catalogs OWNER TO sauron;
 
+
+/* Catalog zone groups support (RFC 9432 §5.2) */
+
+/** This table stores group assignments for catalog zone memberships. **/
+
+CREATE TABLE zone_catalog_groups (
+       id              SERIAL PRIMARY KEY,    /* unique ID */
+       zone_catalog_id INT4 NOT NULL,         /* ptr to zone_catalogs table
+                                                -->zone_catalogs.id */
+       group_name      TEXT NOT NULL CHECK(group_name <> ''),
+                                              /* RFC 9432 group property name */
+
+       /* Constraints */
+       CONSTRAINT zone_catalog_groups_fk FOREIGN KEY (zone_catalog_id)
+           REFERENCES zone_catalogs(id) ON DELETE CASCADE,
+       CONSTRAINT zone_catalog_groups_unique
+           UNIQUE (zone_catalog_id, group_name)
+);
+
+CREATE INDEX idx_zone_catalog_groups_ref ON zone_catalog_groups(zone_catalog_id);
+CREATE INDEX idx_zone_catalog_groups_name ON zone_catalog_groups(group_name);
+
+ALTER TABLE zone_catalog_groups OWNER TO sauron;
+
+
+/** This table stores predefined group definitions for catalog zones. **/
+
+CREATE TABLE catalog_group_defs (
+       id              SERIAL PRIMARY KEY,    /* unique ID */
+       catalog_zone_id INT4 NOT NULL,         /* ptr to zones table - the catalog
+                                                -->zones.id */
+       group_name      TEXT NOT NULL CHECK(group_name <> ''),
+                                              /* group name */
+       comment         TEXT,                  /* description of the group */
+
+       /* Constraints */
+       CONSTRAINT catalog_group_defs_fk FOREIGN KEY (catalog_zone_id)
+           REFERENCES zones(id) ON DELETE CASCADE,
+       CONSTRAINT catalog_group_defs_unique
+           UNIQUE (catalog_zone_id, group_name)
+);
+
+CREATE INDEX idx_catalog_group_defs_catalog ON catalog_group_defs(catalog_zone_id);
+
+ALTER TABLE catalog_group_defs OWNER TO sauron;
+
 /* set DB version */
 
 UPDATE settings SET value='1.8' where setting='dbversion';

--- a/sql/zone_catalog_groups.sql
+++ b/sql/zone_catalog_groups.sql
@@ -1,0 +1,32 @@
+/* zone_catalog_groups table creation
+ *
+ * table to store group assignments for catalog zone members
+ * A member zone can belong to multiple groups within a catalog (RFC 9432 §5.2)
+ *
+ * Groups allow secondary servers to apply different configurations
+ * to different sets of member zones (e.g., different DNSSEC policies,
+ * also-notify lists, etc.)
+ *
+ * $Id:$
+ */
+
+/** This table stores group assignments for catalog zone memberships. **/
+
+CREATE TABLE zone_catalog_groups (
+       id              SERIAL PRIMARY KEY,    /* unique ID */
+       zone_catalog_id INT4 NOT NULL,         /* ptr to zone_catalogs table
+                                                -->zone_catalogs.id */
+       group_name      TEXT NOT NULL CHECK(group_name <> ''),
+                                              /* RFC 9432 group property name */
+
+       /* Constraints */
+       CONSTRAINT zone_catalog_groups_fk FOREIGN KEY (zone_catalog_id)
+           REFERENCES zone_catalogs(id) ON DELETE CASCADE,
+       CONSTRAINT zone_catalog_groups_unique
+           UNIQUE (zone_catalog_id, group_name)
+);
+
+/* Indexes for fast lookups */
+CREATE INDEX idx_zone_catalog_groups_ref ON zone_catalog_groups(zone_catalog_id);
+CREATE INDEX idx_zone_catalog_groups_name ON zone_catalog_groups(group_name);
+


### PR DESCRIPTION
Implement multi-group membership for catalog zone members per RFC 9432 section 5.2. Zones can be assigned to multiple named groups per catalog, allowing secondary servers to apply per-group configuration policies.

Changes:
- New tables:
   - `zone_catalog_groups` (N:M membership-to-group),
   - `catalog_group_defs` (predefined groups per catalog zone)
- Update migration script: `sql/dbconvert_1.7to1.8`
- `BackEnd.pm`: 7 new functions for group CRUD and membership management, updated `get_zone`, `update_zone`, `_delete_zone_parts` for group support
- `CGIutil.pm`: new ftype 15 for per-catalog group checkbox rendering
- `CGI/Zones.pm`: CatalogGroups management page with usage tracking and delete confirmation, group badges in member display
- `sauron.cgi`: "Catalog Groups" menu item in zones submenu
- `sauron`: emit group TXT records for catalog members
- `createtables`: include new SQL table files