### PR TITLE
Modifying dot files/directories in the .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,12 @@ config.h
 doc/tables.html
 doc/tables.sgml
 
-# dot files and dirs
+# dot files
 .*
+
+# don't ignore (yourself, github, ...)
+!.gitignore 
+!.github/
+
 
 # eof


### PR DESCRIPTION
We don't want to ignore all dot files/directories. Currently, all are ignored except for those explicitly listed.