### PR TITLE
Add SOA parameter editing for catalog zones

### DIFF
--- a/Sauron/CGI/Zones.pm
+++ b/Sauron/CGI/Zones.pm
@@ -86,7 +86,7 @@ my %zone_form = (
   {ftype=>2, tag=>'masters', name=>'Masters', type=>['ip','text'], fields=>2,
    len=>[43,45], empty=>[0,1], elabels=>['IP','comment'], iff=>['type','S']},
   {ftype=>1, tag=>'hostmaster', name=>'Hostmaster', type=>'domain', len=>30,
-   empty=>1, definfo=>['','Default (from server)'], iff=>['type','M']},
+   empty=>1, definfo=>['','Default (from server)'], iff=>['type','[MC]']},
   {ftype=>3, tag=>'chknames', name=>'Check-names', type=>'enum',
    conv=>'U', enum=>\%check_names_enum},
   {ftype=>3, tag=>'nnotify', name=>'Notify', type=>'enum', conv=>'U',
@@ -99,18 +99,18 @@ my %zone_form = (
   {ftype=>1, tag=>'transfer_source_v6', name=>'Transfer-Source (IPv6 address)',
    type=>'ip6', len=>39,
    empty=>1, definfo=>['','Default (from server)'], iff=>['type','S']},
-  {ftype=>4, tag=>'serial', name=>'Serial', iff=>['type','M']},
+  {ftype=>4, tag=>'serial', name=>'Serial', iff=>['type','[MC]']},
   {ftype=>1, tag=>'refresh', name=>'Refresh', type=>'int', len=>10,
-   empty=>1, definfo=>['','Default (from server)'], iff=>['type','M']},
+   empty=>1, definfo=>['','Default (from server)'], iff=>['type','[MC]']},
   {ftype=>1, tag=>'retry', name=>'Retry', type=>'int', len=>10,
-   empty=>1, definfo=>['','Default (from server)'], iff=>['type','M']},
+   empty=>1, definfo=>['','Default (from server)'], iff=>['type','[MC]']},
   {ftype=>1, tag=>'expire', name=>'Expire', type=>'int', len=>10,
-   empty=>1, definfo=>['','Default (from server)'], iff=>['type','M']},
+   empty=>1, definfo=>['','Default (from server)'], iff=>['type','[MC]']},
   {ftype=>1, tag=>'minimum', name=>'Minimum (negative caching TTL)',
    empty=>1, definfo=>['','Default (from server)'], type=>'int', len=>10,
-   iff=>['type','M']},
+   iff=>['type','[MC]']},
   {ftype=>1, tag=>'ttl', name=>'Default TTL', type=>'int', len=>10,
-   empty=>1, definfo=>['','Default (from server)'], iff=>['type','M']},
+   empty=>1, definfo=>['','Default (from server)'], iff=>['type','[MC]']},
   {ftype=>5, tag=>'ip', name=>'IP addresses', iff=>['type','M'],
    iff2=>['reverse','f']},
   {ftype=>2, tag=>'ns', name=>'Name servers (NS)', type=>['fqdn','text'],
@@ -538,6 +538,12 @@ sub menu_handler {
 	    return;
 	  }
 	  $data{reversenet}=$new_net;
+	}
+
+	# RFC 9432: Catalog zones use TTL=0 and negative caching TTL=0
+	if ($data{type} eq 'C') {
+	  $data{ttl} = 0;
+	  $data{minimum} = 0;
 	}
 
 	$res=add_zone(\%data);

--- a/sauron
+++ b/sauron
@@ -525,10 +525,10 @@ sub make_dns() {
         $ttl='';
     }
 
-    $ttl_refresh = ($zone{refresh} ? $zone{refresh} : $server{refresh});
-    $ttl_retry = ($zone{retry} ? $zone{retry} : $server{retry});
-    $ttl_expire = ($zone{expire} ? $zone{expire} : $server{expire});
-    $ttl_minimum = ($zone{minimum} ? $zone{minimum} : $server{minimum});
+    $ttl_refresh = (defined($zone{refresh}) && $zone{refresh} ne '' ? $zone{refresh} : $server{refresh});
+    $ttl_retry = (defined($zone{retry}) && $zone{retry} ne '' ? $zone{retry} : $server{retry});
+    $ttl_expire = (defined($zone{expire}) && $zone{expire} ne '' ? $zone{expire} : $server{expire});
+    $ttl_minimum = (defined($zone{minimum}) && $zone{minimum} ne '' ? $zone{minimum} : $server{minimum});
 
     undef @q;
     db_query("SELECT MAX(h.mdate),MAX(h.cdate) " .
@@ -573,7 +573,7 @@ sub make_dns() {
     fatal("no hostmaster defined either in server nor zone record for: " .
           "$zonename") if ($hostmaster eq '');
     fatal("server hostname not defined!") if ($hostname eq '');
-    fatal("no TTL defined!") unless ($TTL > 0);
+    fatal("no TTL defined!") unless ($TTL > 0 || $zone{type} eq 'C');
     if ($bind_conf) {
       print ZONEFILE '$TTL ' . "$TTL\t; default TTL for this zone\n;\n";
       print ZONEFILE '$ORIGIN ' . "$zonename.\n;\n";


### PR DESCRIPTION
- Change iff condition from `'M'` to `'[MC]'` for hostmaster, serial, refresh, retry, expire, minimum, and ttl fields in zone edit form
- Set TTL and negative caching TTL to 0 when creating catalog zones (RFC 9432)
- Allow TTL=0 in zone file generation for catalog zones
- Use `defined()` checks for SOA values so explicit 0 is not replaced by server defaults