### PR TITLE
Add aggregate catalog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,16 @@ jobs:
         run: prove -lv t/12-zone-roundtrip.t
         shell: bash
 
+      - name: Run catalog aggregate tests (TAP)
+        env:
+          PERL5LIB: "/usr/local/sauron:${{ github.workspace }}"
+          SAURON_TEST_DSN: "dbi:Pg:dbname=sauron_test;host=postgres"
+          SAURON_TEST_USER: ${{ env.POSTGRES_USER }}
+          SAURON_TEST_PASSWORD: ${{ env.POSTGRES_PASSWORD }}
+          SAURON_INSTALL_DIR: /usr/local/sauron
+        run: prove -lv t/13-catalog-aggregate.t
+        shell: bash
+
       - name: Dump DB for artifacts
         if: always()
         run: |

--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,27 @@
 	  - BIND zone file generator outputs group TXT records per member
 	  - New tables: zone_catalog_groups, catalog_group_defs
 	  - New "Catalog Groups" menu item and inline link from catalog zone view
+	- Added Aggregate Catalog Zones (type A) for multi-source catalog
+	  merging (RFC 9432) [svamberg]
+	  - New zone type 'A' merges members from multiple source catalog
+	    zones (type C) into a single output catalog zone
+	  - Priority-based conflict resolution when the same member zone
+	    appears in multiple source catalogs (lower priority wins)
+	  - New table: catalog_compositions (source/priority mapping)
+	  - CGI composition editor (ftype 16) for selecting sources and
+	    setting priorities
+	  - Generator produces merged zone file with conflict reporting
+	- Added 'catalog_only' flag for zones [svamberg]
+	  - Zones marked catalog_only are skipped entirely during generation
+	    (no named.conf entry, no zone file)
+	  - Intended for shadow catalog zones imported from external sources
+	- Added import-catalog-zone script [svamberg]
+	  - Imports external catalog zones via AXFR or zone file
+	  - Parses RFC 9432 PTR (member zones) and TXT (group assignments)
+	  - Creates shadow catalog zone (type C, catalog_only) in Sauron
+	  - --sync mode for incremental updates (add new, remove stale members)
+	  - --dryrun mode for safe preview without database changes
+	  - Automatic group definition creation from imported catalog data
 	- Added new option --keep-pending for sauron command [svamberg]
 	- Add check-reverse utility script for DNS PTR record validation [svamberg]
 	  - Verifies that A/AAAA records have corresponding PTR records in DNS

--- a/ChangeLog
+++ b/ChangeLog
@@ -42,6 +42,8 @@
 	  - Creates shadow catalog zone (type C, catalog_only) in Sauron
 	  - --sync mode for incremental updates (add new, remove stale members)
 	  - --dryrun mode for safe preview without database changes
+	  - --group option auto-creates Sauron group if it does not exist
+	  - --ignore-groups option skips RFC 9432 group TXT records
 	  - Automatic group definition creation from imported catalog data
 	- Added new option --keep-pending for sauron command [svamberg]
 	- Add check-reverse utility script for DNS PTR record validation [svamberg]

--- a/ChangeLog
+++ b/ChangeLog
@@ -42,7 +42,7 @@
 	  - Creates shadow catalog zone (type C, catalog_only) in Sauron
 	  - --sync mode for incremental updates (add new, remove stale members)
 	  - --dryrun mode for safe preview without database changes
-	  - --group option auto-creates Sauron group if it does not exist
+	  - --group option auto-creates catalog group definition (zone-scoped)
 	  - --ignore-groups option skips RFC 9432 group TXT records
 	  - Automatic group definition creation from imported catalog data
 	- Added new option --keep-pending for sauron command [svamberg]

--- a/ChangeLog
+++ b/ChangeLog
@@ -59,6 +59,7 @@
 	    - t/10-db-integration.t: database connectivity tests (requires SAURON_TEST_DSN)
 	    - t/11-import-generate.t: end-to-end import-zone/generatehosts/sauron tests
 	    - t/12-zone-roundtrip.t: zone import → generate → compare round-trip test
+	    - t/13-catalog-aggregate.t: import catalog zones, aggregate, compare tests
 	  - Added zone canonicalization tool (t/zone-canonicalize.pl) for
 	    diff-based comparison of zone files (normalizes FQDN, case, SOA serial)
 	  - Added comprehensive test zone (test/roundtrip.example.com.zone) with

--- a/Makefile.in
+++ b/Makefile.in
@@ -83,7 +83,8 @@ SQL_TABLES =	sql/common.sql \
 		sql/keys.sql sql/acls.sql sql/leases.sql \
 		sql/sshfp_entries.sql sql/tlsa_entries.sql \
 		sql/ds_entries.sql sql/naptr_entries.sql \
-		sql/catalog_group_defs.sql sql/zone_catalog_groups.sql
+		sql/catalog_group_defs.sql sql/zone_catalog_groups.sql \
+		sql/catalog_compositions.sql
 
 
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -102,7 +102,8 @@ PROGS = sauron addgroup adduser deluser delgroup modhosts \
 	expire-hosts createtables import-zone remove-hosts \
 	update-hosts export-vmps import-nets import-dhcp \
 	export-ip-list export-hosts export-by-group keygen \
-	addzone import-zone-comments compare-zones check-reverse
+	addzone import-zone-comments compare-zones check-reverse \
+	import-catalog-zone
 
 MODULES = Sauron/Util.pm Sauron/BackEnd.pm Sauron/CGIutil.pm \
 	  Sauron/UtilZone.pm Sauron/Sauron.pm Sauron/UtilDhcp.pm \

--- a/Sauron/BackEnd.pm
+++ b/Sauron/BackEnd.pm
@@ -179,6 +179,11 @@ $VERSION = '$Id:$ ';
 	     get_member_groups
 	     set_member_groups
 	     get_catalog_group_usage
+
+	     get_catalog_compositions
+	     add_catalog_composition
+	     remove_catalog_composition
+	     update_catalog_compositions
 	    );
 
 # Catalog zones support (RFC 9432) - six functions exported above
@@ -1322,16 +1327,16 @@ sub get_zone($$) {
   my ($res,@q,$hid,$sid);
 
   $res = get_record("zones",
-	       "server,active,dummy,type,reverse,class,name,nnotify," .
+	       "server,active,dummy,catalog_only,type,reverse,class,name,nnotify," .
 	       "hostmaster,serial,refresh,retry,expire,minimum,ttl," .
 	       "chknames,reversenet,comment,cdate,cuser,mdate,muser," .
 	       "forward,serial_date,flags,rdate,transfer_source,transfer_source_v6,expiration",
 	       $id,$rec,"id");
   return -1 if ($res < 0);
-  fix_bools($rec,"active,dummy,reverse,noreverse");
+  fix_bools($rec,"active,dummy,catalog_only,reverse,noreverse");
   $sid=$rec->{server};
 
-  if ($rec->{type} eq 'M' || $rec->{type} eq 'C') {
+  if ($rec->{type} eq 'M' || $rec->{type} eq 'C' || $rec->{type} eq 'A') {
     $hid=get_host_id($id,'@');
     if ($hid > 0) {
       get_array_field("ns_entries",3,"id,ns,comment","NS,Comments",
@@ -1431,6 +1436,50 @@ sub get_zone($$) {
     } else {
       $rec->{catalog_group_defs_list} = 'None';
     }
+  } elsif ($rec->{type} eq 'A') {
+    # Aggregate catalog zone - load compositions
+    my $rec_comps = {};
+    get_catalog_compositions($id, $rec_comps);
+    $rec->{compositions} = $rec_comps->{compositions};
+    $rec->{composition_count} = $rec_comps->{count};
+
+    # Format compositions list for display
+    if ($rec_comps->{count} > 0) {
+      my @comp_list;
+      for my $comp (@{$rec_comps->{compositions}}) {
+        my $src_name = $comp->[2];
+        my $prio = $comp->[3];
+        push @comp_list, "$src_name (priority=$prio)";
+      }
+      $rec->{compositions_list} = join(', ', @comp_list);
+    } else {
+      $rec->{compositions_list} = 'None';
+    }
+
+    # Load available source catalog zones for selection
+    my @avail;
+    db_query("SELECT id, name, comment FROM zones " .
+             "WHERE server = $sid AND type = 'C' " .
+             "ORDER BY name", \@avail);
+    $rec->{available_source_catalogs} = \@avail;
+
+    # Build list of currently selected source IDs
+    my @selected_ids;
+    if ($rec_comps->{count} > 0) {
+      for my $comp (@{$rec_comps->{compositions}}) {
+        push @selected_ids, $comp->[1];  # source_zone_id
+      }
+    }
+    $rec->{selected_source_catalogs} = \@selected_ids;
+
+    # Build priorities hash {source_zone_id => priority}
+    my %prio_hash;
+    if ($rec_comps->{count} > 0) {
+      for my $comp (@{$rec_comps->{compositions}}) {
+        $prio_hash{$comp->[1]} = $comp->[3];
+      }
+    }
+    $rec->{composition_priorities} = \%prio_hash;
   } else {
     # Zone is a regular zone - load which catalogs contain it
     my $rec_cats = {};
@@ -1479,6 +1528,10 @@ sub update_zone($) {
   my $selected_catalogs = $rec->{catalog_zones_selected} || [];
   my $selected_member_groups = $rec->{member_groups} || {};
 
+  # Aggregate catalog zones support - save before cleanup
+  my $selected_compositions = $rec->{selected_source_catalogs} || [];
+  my $composition_priorities = $rec->{composition_priorities} || {};
+
   # Catalog zones support - clean up before update
   delete $rec->{catalog_members};
   delete $rec->{catalog_member_count};
@@ -1493,6 +1546,14 @@ sub update_zone($) {
   delete $rec->{catalog_group_defs_list};
   delete $rec->{catalog_group_manage_link};
   delete $rec->{member_groups};
+
+  # Aggregate catalog zones support - clean up before update
+  delete $rec->{compositions};
+  delete $rec->{composition_count};
+  delete $rec->{compositions_list};
+  delete $rec->{available_source_catalogs};
+  delete $rec->{selected_source_catalogs};
+  delete $rec->{composition_priorities};
 
   $rec->{flags}=0;
   $rec->{flags}|=0x01 if ($rec->{txt_auto_generation});
@@ -1519,13 +1580,13 @@ sub update_zone($) {
   if ($r < 0) { db_rollback(); return $r; }
 
   return -199 unless ($rec->{type});
-  if ($rec->{type} eq 'M' || $rec->{type} eq 'C') {
+  if ($rec->{type} eq 'M' || $rec->{type} eq 'C' || $rec->{type} eq 'A') {
     $hid=get_host_id($id,'@');
 
-    # If host record doesn't exist for catalog or master zone, create it
+    # If host record doesn't exist for catalog/aggregate/master zone, create it
     if ($hid <= 0) {
-      if ($rec->{type} eq 'C') {
-        # For catalog zones, create the @ host record if missing
+      if ($rec->{type} eq 'C' || $rec->{type} eq 'A') {
+        # For catalog/aggregate zones, create the @ host record if missing
         $hid = add_record('hosts',{zone=>$id,type=>10,domain=>'@',
                                    comment=>'zone record'});
         if ($hid < 0) { db_rollback(); return -201; }
@@ -1670,6 +1731,17 @@ sub update_zone($) {
           return -26;
         }
       }
+    }
+  }
+
+  # Process aggregate catalog zone composition changes
+  if ($rec->{type} eq 'A' && $id > 0) {
+    $r = update_catalog_compositions($id, $selected_compositions,
+                                     $composition_priorities);
+    if ($r < 0) {
+      write2log("ERROR: Failed to update compositions for aggregate zone $id: $r");
+      db_rollback();
+      return -27;
     }
   }
 
@@ -1856,7 +1928,7 @@ sub add_zone($) {
   $rec->{id}=$id=$res;
 
 
-  if ($rec->{type} eq 'M' || $rec->{type} eq 'C') {
+  if ($rec->{type} eq 'M' || $rec->{type} eq 'C' || $rec->{type} eq 'A') {
     # zone's host record (@)
     $res = add_record('hosts',{zone=>$id,type=>10,domain=>'@',
 			       comment=>'zone record'});
@@ -4906,6 +4978,141 @@ sub get_catalog_group_usage($$$) {
 
   $rec->{count} = scalar @q;
   $rec->{zones} = \@q;
+
+  return 0;
+}
+
+
+# Aggregate catalog zone (type 'A') composition functions
+
+# get_catalog_compositions($composite_zone_id, $rec)
+# Returns list of source catalog zones that compose an aggregate zone.
+# rec->{compositions} = [[id, source_zone_id, name, priority], ...]
+# rec->{count} = number of source zones
+sub get_catalog_compositions($$) {
+  my($composite_zone_id, $rec) = @_;
+  my(@q);
+
+  return -1 unless ($composite_zone_id > 0);
+
+  $rec = {} unless (ref($rec) eq 'HASH');
+
+  db_query("SELECT cc.id, cc.source_zone_id, z.name, cc.priority " .
+           "FROM catalog_compositions cc " .
+           "JOIN zones z ON cc.source_zone_id = z.id " .
+           "WHERE cc.composite_zone_id = $composite_zone_id " .
+           "ORDER BY cc.priority ASC, z.name", \@q);
+
+  $rec->{count} = scalar @q;
+  $rec->{compositions} = \@q;
+
+  return 0;
+}
+
+
+# add_catalog_composition($composite_zone_id, $source_zone_id, $priority)
+# Adds a source catalog zone to an aggregate zone.
+sub add_catalog_composition($$$) {
+  my($composite_zone_id, $source_zone_id, $priority) = @_;
+  my($res, @q);
+
+  return -1 unless ($composite_zone_id > 0 && $source_zone_id > 0);
+  return -2 if ($composite_zone_id == $source_zone_id);
+  $priority = 100 unless (defined($priority) && $priority > 0);
+
+  # Verify composite zone is type 'A'
+  db_query("SELECT type FROM zones WHERE id=$composite_zone_id", \@q);
+  return -3 unless (@q > 0 && $q[0][0] eq 'A');
+
+  # Verify source zone is type 'C'
+  db_query("SELECT type FROM zones WHERE id=$source_zone_id", \@q);
+  return -4 unless (@q > 0 && $q[0][0] eq 'C');
+
+  # Check if already exists
+  db_query("SELECT id FROM catalog_compositions " .
+           "WHERE composite_zone_id=$composite_zone_id " .
+           "AND source_zone_id=$source_zone_id", \@q);
+  return -10 if (@q > 0);
+
+  $res = db_exec("INSERT INTO catalog_compositions " .
+                 "(composite_zone_id, source_zone_id, priority) " .
+                 "VALUES($composite_zone_id, $source_zone_id, $priority)");
+
+  return $res;
+}
+
+
+# remove_catalog_composition($composite_zone_id, $source_zone_id)
+# Removes a source catalog zone from an aggregate zone.
+sub remove_catalog_composition($$) {
+  my($composite_zone_id, $source_zone_id) = @_;
+
+  return -1 unless ($composite_zone_id > 0 && $source_zone_id > 0);
+
+  return db_exec("DELETE FROM catalog_compositions " .
+                 "WHERE composite_zone_id=$composite_zone_id " .
+                 "AND source_zone_id=$source_zone_id");
+}
+
+
+# update_catalog_compositions($composite_zone_id, $selected_sources, $priorities)
+# Diff-based update of aggregate zone compositions.
+# $selected_sources = arrayref of source_zone_ids
+# $priorities = hashref {source_zone_id => priority}
+sub update_catalog_compositions($$$) {
+  my($composite_zone_id, $selected_sources, $priorities) = @_;
+  my($r, @q);
+
+  return -1 unless ($composite_zone_id > 0);
+
+  # Get current compositions
+  db_query("SELECT source_zone_id, priority FROM catalog_compositions " .
+           "WHERE composite_zone_id = $composite_zone_id", \@q);
+  my %current;
+  for my $row (@q) {
+    $current{$row->[0]} = $row->[1];
+  }
+
+  # Build new state
+  my @new_sources = ref($selected_sources) eq 'ARRAY' ? @{$selected_sources} : ();
+  my %new_hash;
+  for my $src_id (@new_sources) {
+    my $prio = (ref($priorities) eq 'HASH' && $priorities->{$src_id})
+               ? int($priorities->{$src_id}) : 100;
+    $prio = 1 if ($prio < 1);
+    $new_hash{$src_id} = $prio;
+  }
+
+  # Remove compositions no longer selected
+  for my $src_id (keys %current) {
+    unless ($new_hash{$src_id}) {
+      $r = db_exec("DELETE FROM catalog_compositions " .
+                   "WHERE composite_zone_id=$composite_zone_id " .
+                   "AND source_zone_id=$src_id");
+      return $r if ($r < 0);
+    }
+  }
+
+  # Add or update compositions
+  for my $src_id (keys %new_hash) {
+    my $prio = $new_hash{$src_id};
+    if ($current{$src_id}) {
+      # Update priority if changed
+      if ($current{$src_id} != $prio) {
+        $r = db_exec("UPDATE catalog_compositions " .
+                     "SET priority=$prio " .
+                     "WHERE composite_zone_id=$composite_zone_id " .
+                     "AND source_zone_id=$src_id");
+        return $r if ($r < 0);
+      }
+    } else {
+      # Add new composition
+      $r = db_exec("INSERT INTO catalog_compositions " .
+                   "(composite_zone_id, source_zone_id, priority) " .
+                   "VALUES($composite_zone_id, $src_id, $prio)");
+      return $r if ($r < 0);
+    }
+  }
 
   return 0;
 }

--- a/Sauron/CGI/Zones.pm
+++ b/Sauron/CGI/Zones.pm
@@ -37,7 +37,7 @@ sub write2log{
 } # End of write2log
 
 
-my %ztypenames=(M=>'master',S=>'slave',F=>'forward',H=>'hint',C=>'catalog');
+my %ztypenames=(M=>'master',S=>'slave',F=>'forward',H=>'hint',C=>'catalog',A=>'aggregate');
 
 my %naptr_flags=(
     0=>'(non-terminal)',
@@ -55,7 +55,7 @@ my %new_zone_form=(
   {ftype=>1, tag=>'comment', name=>'Comments', type=>'text', len=>80, maxlen=>200, 
    empty=>1, anchor=>1, whitesp=>'P'},
   {ftype=>3, tag=>'type', name=>'Type', type=>'enum', conv=>'U',
-   enum=>{M=>'Master', S=>'Slave', H=>'Hint', F=>'Forward', C=>'Catalog'}},
+   enum=>{M=>'Master', S=>'Slave', H=>'Hint', F=>'Forward', C=>'Catalog', A=>'Aggregate Catalog'}},
   {ftype=>3, tag=>'reverse', name=>'Reverse', type=>'enum',  conv=>'L',
    enum=>{f=>'No',t=>'Yes'}, iff=>['type','M']}
  ]
@@ -73,7 +73,7 @@ my %zone_form = (
   {ftype=>1, tag=>'comment', name=>'Comments', type=>'text', len=>80, maxlen=>200, # TVu.
    empty=>1, anchor=>1, whitesp=>'P'},
   {ftype=>4, tag=>'type', name=>'Type', type=>'enum', conv=>'U',
-   enum=>{M=>'Master', S=>'Slave', H=>'Hint', F=>'Forward', C=>'Catalog'}},
+   enum=>{M=>'Master', S=>'Slave', H=>'Hint', F=>'Forward', C=>'Catalog', A=>'Aggregate Catalog'}},
   {ftype=>4, tag=>'reverse', name=>'Reverse', type=>'enum',
    enum=>{f=>'No',t=>'Yes'}, iff=>['type','M']},
   {ftype=>3, tag=>'txt_auto_generation',
@@ -174,6 +174,9 @@ my %zone_form = (
    fields=>3, len=>[39,6,15], empty=>[0,1,1], elabels=>['IP','Port','comment'],
    iff=>['type','F']},
 
+  {ftype=>3, tag=>'catalog_only', name=>'Catalog-only (suppress generation)',
+   type=>'enum', enum=>{f=>'No',t=>'Yes'}, iff=>['type','C']},
+
   {ftype=>0, name=>'Catalog Zones', iff=>['type','C'], no_edit=>1},
   {ftype=>0, name=>'Catalog Zones', iff=>['type','M']},
   {ftype=>4, tag=>'catalog_member_count', name=>'Member zones count',
@@ -192,6 +195,12 @@ my %zone_form = (
    iff=>['type','M']},
   {ftype=>15, tag=>'member_groups', name=>'Catalog zone groups (RFC 9432)',
    iff=>['type','M']},
+
+  {ftype=>0, name=>'Aggregate Catalog Zone', iff=>['type','A']},
+  {ftype=>4, tag=>'compositions_list', name=>'Source catalog zones',
+   no_edit=>1, iff=>['type','A']},
+  {ftype=>16, tag=>'selected_source_catalogs',
+   name=>'Source catalog zones (with priority)', iff=>['type','A']},
 
   {ftype=>0, name=>'DHCP', iff=>['type','M']},
   {ftype=>2, tag=>'dhcp', name=>'Zone specific DHCP entries',
@@ -237,6 +246,10 @@ sub update_zone_wrapper($) {
   delete $rec->{catalog_group_defs};
   delete $rec->{catalog_group_defs_list};
   delete $rec->{catalog_group_manage_link};
+  delete $rec->{compositions};
+  delete $rec->{composition_count};
+  delete $rec->{compositions_list};
+  delete $rec->{available_source_catalogs};
   delete $rec->{cdate_str};
   delete $rec->{mdate_str};
   delete $rec->{pending_info};
@@ -258,7 +271,7 @@ sub select_zone($$)
   my (%server,%zonelist);
 
   #display zone selection list
-  my %ztypecolors=(M=>'#c0ffc0',C=>'#add0fe',S=>'#eeeeff',F=>'#eedfdf',H=>'#eeeebf');
+  my %ztypecolors=(M=>'#c0ffc0',C=>'#add0fe',S=>'#eeeeff',F=>'#eedfdf',H=>'#eeeebf',A=>'#d0b0ff');
   # 2022-08-10 mesrik: add last expired arg, no skipping here
   my $list=get_zone_list($serverid,0,0,0);
 # my $zlimit = 50; # Limit removed.
@@ -333,8 +346,8 @@ sub select_zone($$)
 
   get_server($serverid,\%server);
   if ($server{masterserver} > 0) {
-    %ztypecolors=(M=>'#eedeff',S=>'#eeeeff',F=>'#eedfdf',H=>'#eeeebf');
-    %ztypenames=(M=>'Slave (Master)',S=>'Slave',F=>'Forward',H=>'Hint');
+    %ztypecolors=(M=>'#eedeff',S=>'#eeeeff',F=>'#eedfdf',H=>'#eeeebf',C=>'#add0fe',A=>'#d0b0ff');
+    %ztypenames=(M=>'Slave (Master)',S=>'Slave',F=>'Forward',H=>'Hint',C=>'Catalog',A=>'Aggregate');
 
     print h4("Zones from master server:"),
           p,"<TABLE width=98% bgcolor=white border=0>",

--- a/Sauron/CGIutil.pm
+++ b/Sauron/CGIutil.pm
@@ -688,6 +688,23 @@ sub form_check_form($$$) {
       }
       $data->{$tag} = \%member_groups;
     }
+    elsif ($type == 16) { # Catalog composition editor (check input)
+      # Collect selected source catalog zones and priorities
+      my @selected = ();
+      my %priorities;
+      my $count = param($p."_count") || 0;
+      for my $j (0..$count-1) {
+        my $val = param($p."_".$j);
+        if (defined $val && $val) {
+          push @selected, int($val);
+          my $prio = param($p."_prio_".$j);
+          $prio = 100 unless (defined $prio && $prio > 0);
+          $priorities{int($val)} = int($prio);
+        }
+      }
+      $data->{$tag} = \@selected;
+      $data->{composition_priorities} = \%priorities;
+    }
   }
   return 0;
 }
@@ -1518,6 +1535,52 @@ sub form_magic($$$) {
 				 -value=>$gname, -checked=>$is_checked), "</TD>";
 	}
 	print "</TR>";
+      }
+      print "</TABLE></TD>";
+    }
+    elsif ($rec->{ftype} == 16) { # Catalog composition editor (edit)
+      print td($rec->{name}), "<TD><TABLE>";
+      my $available = $data->{'available_source_catalogs'} || [];
+      my $selected = $data->{$rec->{tag}} || [];
+      my %sel_hash = map { $_ => 1 } @{$selected};
+      my $priorities = $data->{'composition_priorities'} || {};
+      my $total_count = scalar(@{$available});
+
+      # Load current params if form is being re-edited
+      my $count = param($p1."_count");
+      if (defined $count && $count > 0) {
+        %sel_hash = ();
+        %{$priorities} = ();
+        for $j (0..$count-1) {
+          my $cat_id = param($p1."_".$j);
+          if ($cat_id) {
+            $sel_hash{$cat_id} = 1;
+            my $prio = param($p1."_prio_".$j);
+            $priorities->{$cat_id} = $prio if (defined $prio);
+          }
+        }
+      }
+
+      print hidden(-name=>$p1."_count",-value=>$total_count);
+      print "<TR bgcolor=\"#cccccc\">",
+            "<TD><B>Select</B></TD><TD><B>Catalog Zone</B></TD>",
+            "<TD><B>Priority</B></TD><TD><B>Comment</B></TD></TR>";
+
+      for $j (0..$#{$available}) {
+        my $cat_id = $$available[$j][0];
+        my $cat_name = $$available[$j][1];
+        my $cat_comment = $$available[$j][2] || '';
+        my $is_checked = $sel_hash{$cat_id} ? 'on' : '';
+        my $prio_val = $priorities->{$cat_id} || 100;
+
+        print "<TR><TD>",
+              checkbox(-label=>'', -name=>$p1."_".$j,
+                       -value=>$cat_id, -checked=>$is_checked),
+              "</TD><TD>$cat_name</TD><TD>",
+              textfield(-name=>$p1."_prio_".$j, -size=>5,
+                        -maxlength=>5, -value=>$prio_val,
+                        -override=>1),
+              "</TD><TD>$cat_comment</TD></TR>";
       }
       print "</TABLE></TD>";
     }

--- a/Sauron/CGIutil.pm
+++ b/Sauron/CGIutil.pm
@@ -1582,7 +1582,10 @@ sub form_magic($$$) {
                         -override=>1),
               "</TD><TD>$cat_comment</TD></TR>";
       }
-      print "</TABLE></TD>";
+      print "<tr><td colspan=4><font size=-1 color=\"blue\">",
+            "Priority is used to determine the order of catalogs in the composition. Lower values have higher priority.",
+            "</font></td></tr>",
+            "</TABLE></TD>";
     }
     elsif ($rec->{ftype} == 101) {
       undef @q; undef @lst; undef %lsth;

--- a/createtables
+++ b/createtables
@@ -41,6 +41,7 @@ load_config();
 		sql/sshfp_entries.sql sql/tlsa_entries.sql sql/ds_entries.sql
 		sql/naptr_entries.sql
 		sql/zone_catalog_groups.sql sql/catalog_group_defs.sql
+		sql/catalog_compositions.sql
 		@;
 
 

--- a/import-catalog-zone
+++ b/import-catalog-zone
@@ -28,6 +28,8 @@ load_config();
 
 ##############################
 
+Getopt::Long::Configure('permute');
+
 GetOptions("help|h", "verbose|v", "dryrun|dry-run|n", "sync",
 	   "nameserver=s", "axfr-zone=s", "axfr-port=i",
 	   "catalog-only", "group=s", "ignore-groups",
@@ -45,8 +47,8 @@ if ($opt_help || @ARGV < 2) {
 	"\t--nameserver=<spec>\tAXFR source: <host>[:port][/zone]\n",
 	"\t--axfr-zone=<zone>\toverride zone name used for AXFR\n",
 	"\t--axfr-port=<port>\toverride AXFR TCP port\n",
-	"\t--group=<name>\t\tassign imported member zones to this group\n",
-	"\t\t\t\t(group is auto-created if it does not exist)\n",
+	"--group=<name>\t\tassign imported member zones to this catalog group\n",
+	"\t\t\t\t(group definition is auto-created in the catalog zone)\n",
 	"\t--ignore-groups\t\tignore RFC 9432 group TXT records from import\n",
 	"\t--catalog-only\t\tmark shadow catalog zone as catalog_only\n",
 	"\t\t\t\t(skip named.conf and zone file generation)\n",
@@ -64,6 +66,7 @@ if ($opt_help || @ARGV < 2) {
 $servername = shift;
 $catalogname = shift;
 $zonefile = shift;  # optional third positional arg
+fatal("too many arguments: " . join(' ', @ARGV)) if (@ARGV > 0);
 $axfr_zone = '';
 $axfr_ns = '';
 $axfr_port = 53;
@@ -120,23 +123,10 @@ if ($opt_nameserver) {
 	unless (valid_domainname($axfr_zone));
 }
 
-# Validate group if specified - auto-create if missing
+# Validate --group name (actual creation deferred until catalog zone is known)
 if ($opt_group) {
-    $gid = get_group_by_name($serverid, $opt_group);
-    if ($gid < 0) {
-	print "Creating group '$opt_group' for server '$servername'\n"
-	    if ($opt_verbose);
-	unless ($opt_dryrun) {
-	    $gid = add_group({server => $serverid, name => $opt_group,
-			       type => 0, comment => "Created by import-catalog-zone",
-			       dhcp => [], dhcp6 => [], printer => []});
-	    fatal("cannot create group '$opt_group' (error=$gid)") if ($gid < 0);
-	    print "  Created group '$opt_group' (id=$gid)\n" if ($opt_verbose);
-	} else {
-	    print "[dry-run] Would create group: $opt_group\n";
-	    $gid = -999;
-	}
-    }
+    fatal("invalid --group name: $opt_group")
+	unless ($opt_group =~ /^[a-zA-Z0-9_][a-zA-Z0-9_.:-]*$/);
 }
 
 ##############################
@@ -345,6 +335,22 @@ unless ($opt_dryrun || $opt_ignore_groups) {
     }
 }
 
+# Add --group to catalog group definitions (independent of --ignore-groups)
+if ($opt_group && !$opt_dryrun && !$known_groups{$opt_group}) {
+    print "  Adding group definition: $opt_group\n" if ($opt_verbose);
+    my $res = add_catalog_group_def($catalog_zone_id, $opt_group,
+				    "Created by import-catalog-zone --group");
+    if ($res < 0 && $res != -10) {
+	print STDERR "WARNING: cannot add group definition '$opt_group' (error=$res)\n";
+    } else {
+	$known_groups{$opt_group} = 1;
+	print "  Created group '$opt_group' for catalog zone (id=$catalog_zone_id)\n"
+	    if ($opt_verbose);
+    }
+} elsif ($opt_group && $opt_dryrun) {
+    print "[dry-run] Would create group definition: $opt_group\n";
+}
+
 ##############################
 # Process member zones
 
@@ -461,30 +467,18 @@ foreach my $uuid (sort { $members{$a}{name} cmp $members{$b}{name} } @member_uui
 	$skipped++ unless ($opt_sync);
     }
 
-    # Set groups for member
-    if (@mgroups > 0 && !$opt_ignore_groups) {
+    # Add explicit --group to member group list
+    if ($opt_group) {
+	push @mgroups, $opt_group unless grep { $_ eq $opt_group } @mgroups;
+    }
+
+    # Set groups for member (skip only when ignoring groups AND no explicit --group)
+    if (@mgroups > 0 && (!$opt_ignore_groups || $opt_group)) {
 	$res = set_member_groups($zone_id, $catalog_zone_id, \@mgroups);
 	if ($res < 0) {
 	    print STDERR "WARNING: cannot set groups for '$mname' (error=$res)\n";
 	} elsif ($opt_verbose) {
 	    print "    Groups: " . join(', ', @mgroups) . "\n";
-	}
-    }
-
-    # Assign to Sauron group if specified (best-effort)
-    if ($opt_group && $gid > 0) {
-	# Some schemas do not have zones.grp. Use apex host record when present.
-	my @hq;
-	db_query("SELECT id, grp FROM hosts " .
-		 "WHERE zone=$zone_id AND domain='\@' ORDER BY id LIMIT 1", \@hq);
-	if (@hq > 0) {
-	    my $host_id = $hq[0][0];
-	    my $cur_grp = $hq[0][1];
-	    if (!$cur_grp || $cur_grp < 1) {
-		db_exec("UPDATE hosts SET grp=$gid WHERE id=$host_id");
-	    }
-	} elsif ($opt_verbose) {
-	    print "    Note: no apex host record for '$mname'; group assignment skipped\n";
 	}
     }
 }

--- a/import-catalog-zone
+++ b/import-catalog-zone
@@ -345,9 +345,10 @@ foreach my $uuid (sort { $members{$a}{name} cmp $members{$b}{name} } @member_uui
 	my %newzone;
 	$newzone{server}  = $serverid;
 	$newzone{type}    = 'S';
+	$newzone{catalog_only} = 'true';
 	$newzone{reverse} = 'false';
 	$newzone{name}    = $mname;
-	$newzone{comment} = "Imported from catalog $catalogname";
+	$newzone{comment} = "Imported from catalog $catalogname (shadow member)";
 	$newzone{serial}  = 1;
 	$newzone{refresh} = 3600;
 	$newzone{retry}   = 900;

--- a/import-catalog-zone
+++ b/import-catalog-zone
@@ -1,0 +1,440 @@
+#!/usr/bin/perl -I/opt/sauron
+#
+# import-catalog-zone - imports external DNS catalog zone (RFC 9432) into Sauron
+#
+# Creates a shadow catalog zone (type 'C', catalog_only=true) from an
+# external catalog zone obtained via AXFR or from a zone file.
+# Member zones referenced by the catalog are registered in Sauron and
+# added to the shadow catalog with their group assignments.
+#
+# Designed to be run periodically (cron) with --sync to keep the shadow
+# catalog in sync with the external source.
+#
+# Copyright (c) 2025.
+# $Id:$
+#
+require 5;
+use Getopt::Long;
+use Sauron::DB;
+use Sauron::Util;
+use Sauron::UtilZone;
+use Sauron::BackEnd;
+use Sauron::Sauron;
+use Sauron::SetupIO;
+
+set_encoding();
+load_config();
+
+##############################
+
+GetOptions("help|h", "verbose|v", "dryrun|dry-run|n", "sync",
+	   "nameserver=s", "file=s", "catalog-only", "group=s",
+	   "notransaction");
+
+$opt_dryrun = $opt_dryrun || 0;
+$opt_verbose = ($opt_verbose ? 1 : 0);
+$opt_sync = $opt_sync || 0;
+
+if ($opt_help || @ARGV < 2) {
+    print "syntax: $0 [options] <servername> <catalog-zone-name>\n\n";
+    print "Imports an external catalog zone (RFC 9432) into Sauron as a\n";
+    print "shadow catalog zone (type C, catalog_only).\n\n";
+    print "options:\n",
+	"\t--nameserver=<ns>\tuse this nameserver for AXFR transfer\n",
+	"\t--file=<path>\t\timport from zone file instead of AXFR\n",
+	"\t--group=<name>\t\tassign imported member zones to this group\n",
+	"\t--catalog-only\t\tmark shadow catalog zone as catalog_only\n",
+	"\t\t\t\t(skip named.conf and zone file generation)\n",
+	"\t--sync\t\t\tsynchronize: add new members, remove stale ones\n",
+	"\t--dryrun\t\tshow what would be done without making changes\n",
+	"\t--verbose\t\tdisplay detailed progress\n",
+	"\t--notransaction\t\tdo not use transactions\n",
+	"\t--help\t\t\tdisplay this help\n\n";
+    exit(($opt_help ? 0 : 1));
+}
+
+$servername = shift;
+$catalogname = shift;
+
+$user = (getpwuid($<))[0];
+set_muser($user);
+db_connect();
+
+# Validate server
+$serverid = get_server_id($servername);
+fatal("cannot find server: $servername") unless ($serverid > 0);
+
+# Validate nameserver option
+if ($opt_nameserver) {
+    fatal("invalid nameserver: $opt_nameserver")
+	unless (valid_domainname($opt_nameserver) || is_cidr($opt_nameserver));
+}
+
+# Validate catalog zone name
+fatal("invalid catalog zone name: $catalogname")
+    unless (valid_domainname($catalogname));
+$catalogname =~ s/\.$//;
+$origin = $catalogname . '.';
+
+# Validate group if specified
+if ($opt_group) {
+    $gid = get_group_by_name($serverid, $opt_group);
+    fatal("cannot find group: $opt_group") unless ($gid > 0);
+}
+
+##############################
+# Fetch catalog zone data via AXFR or file
+
+print "Fetching catalog zone: $catalogname\n" if ($opt_verbose);
+
+if ($opt_file) {
+    fatal("cannot read zone file: $opt_file") unless (-r $opt_file);
+    process_zonefile($opt_file, $catalogname, \%zonedata, 0);
+} else {
+    process_zonedns($catalogname, \%zonedata, $opt_nameserver, $opt_verbose);
+}
+
+##############################
+# Parse catalog zone contents (RFC 9432)
+#
+# Structure:
+#   version.catalog.<origin>  TXT "2"
+#   <uuid>.zones.catalog.<origin>  PTR <member-zone-name>.
+#   group.<uuid>.zones.catalog.<origin>  TXT "<group-name>"
+
+# Verify catalog version
+$version_key = "version.$origin";
+if ($zonedata{$version_key} && @{$zonedata{$version_key}{TXT}} > 0) {
+    $catver = $zonedata{$version_key}{TXT}[0];
+    $catver =~ s/^"(.*)"$/$1/;  # strip quotes if present
+    fatal("unsupported catalog zone version: $catver (expected '2')")
+	unless ($catver eq '2');
+    print "Catalog zone version: $catver\n" if ($opt_verbose);
+} else {
+    fatal("no version TXT record found in catalog zone (not RFC 9432 compliant)");
+}
+
+# Extract member zones and group assignments
+%members = ();  # uuid => { name => 'zone.name', groups => ['g1', ...] }
+$zones_suffix = "zones.$origin";
+
+foreach $domain (keys %zonedata) {
+    my $rec = $zonedata{$domain};
+
+    # Match PTR records under *.zones.catalog.<origin>
+    # Format: <uuid>.zones.catalog.<origin> PTR <member-zone>.
+    if ($domain =~ /^([^.]+)\.\Q$zones_suffix\E$/i && @{$rec->{PTR}} > 0) {
+	my $uuid = $1;
+	my $member_name = $rec->{PTR}[0];
+	$member_name =~ s/\.$//;  # strip trailing dot
+	$members{$uuid} = { name => lc($member_name), groups => [] }
+	    unless ($members{$uuid});
+	$members{$uuid}{name} = lc($member_name);
+	next;
+    }
+
+    # Match group TXT records: group.<uuid>.zones.catalog.<origin>
+    # Format: group.<uuid>.zones.catalog.<origin> TXT "<group-name>"
+    if ($domain =~ /^group\.([^.]+)\.\Q$zones_suffix\E$/i && @{$rec->{TXT}} > 0) {
+	my $uuid = $1;
+	$members{$uuid} = { name => '', groups => [] }
+	    unless ($members{$uuid});
+	foreach my $txt (@{$rec->{TXT}}) {
+	    my $grpname = $txt;
+	    $grpname =~ s/^"(.*)"$/$1/;  # strip quotes
+	    push @{$members{$uuid}{groups}}, $grpname if ($grpname ne '');
+	}
+	next;
+    }
+}
+
+# Filter out entries without a zone name (group-only orphans)
+@member_uuids = grep { $members{$_}{name} ne '' } keys %members;
+$member_count = scalar @member_uuids;
+
+print "Found $member_count member zones in catalog\n";
+if ($opt_verbose) {
+    foreach my $uuid (sort { $members{$a}{name} cmp $members{$b}{name} } @member_uuids) {
+	my $m = $members{$uuid};
+	my $grps = @{$m->{groups}} > 0 ? ' [' . join(', ', @{$m->{groups}}) . ']' : '';
+	print "  $m->{name}$grps\n";
+    }
+}
+
+fatal("no member zones found in catalog zone") if ($member_count == 0);
+
+exit(0) if ($opt_dryrun && !$opt_sync);
+
+##############################
+# Database operations
+
+unless ($opt_notransaction || $opt_dryrun) {
+    db_begin();
+    db_ignore_begin_and_commit(1);
+}
+
+# Check if shadow catalog zone already exists
+$catalog_zone_id = get_zone_id($catalogname, $serverid);
+
+if ($catalog_zone_id > 0) {
+    # Zone exists - verify it's type 'C'
+    my %existing_zone;
+    fatal("cannot read existing zone: $catalogname")
+	if (get_zone($catalog_zone_id, \%existing_zone) < 0);
+    fatal("zone '$catalogname' exists but is not a catalog zone (type=$existing_zone{type})")
+	unless ($existing_zone{type} eq 'C');
+    print "Using existing shadow catalog zone: $catalogname (id=$catalog_zone_id)\n"
+	if ($opt_verbose);
+} else {
+    # Create new shadow catalog zone
+    print "Creating shadow catalog zone: $catalogname\n";
+
+    if ($opt_dryrun) {
+	print "[dry-run] Would create catalog zone: $catalogname\n";
+	$catalog_zone_id = -999;  # placeholder
+    } else {
+	my $soa_rec = $zonedata{$origin};
+	fatal("no SOA record in catalog zone") unless ($soa_rec && $soa_rec->{SOA});
+
+	my @soa = split(/\s+/, $soa_rec->{SOA});
+
+	my %zonehash;
+	$zonehash{server}   = $serverid;
+	$zonehash{type}     = 'C';
+	$zonehash{reverse}  = 'false';
+	$zonehash{name}     = $catalogname;
+	$zonehash{serial}   = $soa[2];
+	$zonehash{refresh}  = $soa[3];
+	$zonehash{retry}    = $soa[4];
+	$zonehash{expire}   = $soa[5];
+	$zonehash{minimum}  = $soa[6];
+	$zonehash{ttl}      = ($soa_rec->{TTL} > 0 ? $soa_rec->{TTL} : '');
+	$zonehash{comment}  = "Imported catalog zone (shadow)";
+
+	$zonehash{ns} = [];
+	if ($soa_rec->{NS}) {
+	    foreach my $ns (@{$soa_rec->{NS}}) {
+		push @{$zonehash{ns}}, [0, $ns, ''];
+	    }
+	}
+	# Ensure at least one NS if none found
+	if (@{$zonehash{ns}} == 0) {
+	    push @{$zonehash{ns}}, [0, 'invalid.', 'placeholder NS for catalog zone'];
+	}
+
+	$zonehash{mx}    = [];
+	$zonehash{txt}   = [];
+	$zonehash{ip}    = [];
+	$zonehash{naptr} = [];
+
+	$catalog_zone_id = add_zone(\%zonehash);
+	fatal("cannot create shadow catalog zone (error=$catalog_zone_id)")
+	    if ($catalog_zone_id < 0);
+
+	# Set catalog_only flag if requested
+	if (${opt_catalog_only}) {
+	    my $res = db_exec("UPDATE zones SET catalog_only=true WHERE id=$catalog_zone_id");
+	    fatal("cannot set catalog_only flag") if ($res < 0);
+	}
+
+	print "Created shadow catalog zone: id=$catalog_zone_id\n";
+    }
+}
+
+# Ensure group definitions exist in the shadow catalog
+%known_groups = ();
+unless ($opt_dryrun) {
+    # Collect all group names from imported members
+    my %needed_groups;
+    foreach my $uuid (@member_uuids) {
+	foreach my $grp (@{$members{$uuid}{groups}}) {
+	    $needed_groups{$grp} = 1;
+	}
+    }
+
+    # Load existing group definitions
+    my $grp_rec = {};
+    get_catalog_group_defs($catalog_zone_id, $grp_rec);
+    if ($grp_rec->{groups}) {
+	foreach my $g (@{$grp_rec->{groups}}) {
+	    $known_groups{$g->[1]} = $g->[0];  # name => id
+	}
+    }
+
+    # Add missing group definitions
+    foreach my $grpname (sort keys %needed_groups) {
+	unless ($known_groups{$grpname}) {
+	    print "  Adding group definition: $grpname\n" if ($opt_verbose);
+	    my $res = add_catalog_group_def($catalog_zone_id, $grpname,
+					    "Imported from $catalogname");
+	    if ($res < 0) {
+		print STDERR "WARNING: cannot add group definition '$grpname' (error=$res)\n";
+	    } else {
+		$known_groups{$grpname} = 1;
+	    }
+	}
+    }
+}
+
+##############################
+# Process member zones
+
+$added = 0;
+$skipped = 0;
+$failed = 0;
+$removed = 0;
+
+# Build set of imported member zone names for sync
+%imported_names = ();
+foreach my $uuid (@member_uuids) {
+    $imported_names{lc($members{$uuid}{name})} = $uuid;
+}
+
+# Sync mode: remove members no longer in external catalog
+if ($opt_sync && $catalog_zone_id > 0 && !$opt_dryrun) {
+    my $existing_members = {};
+    get_zone_catalog_members($catalog_zone_id, $existing_members);
+
+    if ($existing_members->{count} > 0) {
+	foreach my $m (@{$existing_members->{members}}) {
+	    my $mzone_id   = $m->[0];
+	    my $mzone_name = lc($m->[1]);
+
+	    unless ($imported_names{$mzone_name}) {
+		if ($opt_dryrun) {
+		    print "[dry-run] Would remove stale member: $mzone_name\n";
+		} else {
+		    print "  Removing stale member: $mzone_name\n" if ($opt_verbose);
+		    my $res = remove_zone_from_catalog($mzone_id, $catalog_zone_id);
+		    if ($res < 0) {
+			print STDERR "WARNING: cannot remove member '$mzone_name' (error=$res)\n";
+		    } else {
+			$removed++;
+		    }
+		}
+	    }
+	}
+    }
+}
+
+# Add/update member zones
+foreach my $uuid (sort { $members{$a}{name} cmp $members{$b}{name} } @member_uuids) {
+    my $mname = $members{$uuid}{name};
+    my @mgroups = @{$members{$uuid}{groups}};
+
+    # Check if member zone exists in Sauron
+    my $zone_id = get_zone_id($mname, $serverid);
+
+    if ($zone_id < 0) {
+	# Zone doesn't exist in Sauron - create as slave stub
+	if ($opt_dryrun) {
+	    print "[dry-run] Would create slave zone: $mname\n";
+	    $skipped++;
+	    next;
+	}
+
+	print "  Creating slave zone: $mname\n" if ($opt_verbose);
+
+	my %newzone;
+	$newzone{server}  = $serverid;
+	$newzone{type}    = 'S';
+	$newzone{reverse} = 'false';
+	$newzone{name}    = $mname;
+	$newzone{comment} = "Imported from catalog $catalogname";
+	$newzone{serial}  = 1;
+	$newzone{refresh} = 3600;
+	$newzone{retry}   = 900;
+	$newzone{expire}  = 604800;
+	$newzone{minimum} = 3600;
+	$newzone{ns}      = [];
+	$newzone{mx}      = [];
+	$newzone{txt}     = [];
+	$newzone{ip}      = [];
+	$newzone{naptr}   = [];
+
+	# Use nameserver from AXFR source as NS if available
+	if ($opt_nameserver) {
+	    my $ns = $opt_nameserver;
+	    $ns .= '.' unless ($ns =~ /\.$/);
+	    push @{$newzone{ns}}, [0, $ns, 'from catalog import'];
+	} else {
+	    push @{$newzone{ns}}, [0, 'invalid.', 'placeholder - update manually'];
+	}
+
+	$zone_id = add_zone(\%newzone);
+	if ($zone_id < 0) {
+	    print STDERR "WARNING: cannot create zone '$mname' (error=$zone_id)\n";
+	    $failed++;
+	    next;
+	}
+    }
+
+    # Add zone to catalog (idempotent - returns -10 if already exists)
+    if ($opt_dryrun) {
+	print "[dry-run] Would add to catalog: $mname\n";
+	$added++;
+	next;
+    }
+
+    my $res = add_zone_to_catalog($zone_id, $catalog_zone_id);
+    if ($res < 0 && $res != -10) {
+	print STDERR "WARNING: cannot add '$mname' to catalog (error=$res)\n";
+	$failed++;
+	next;
+    }
+
+    if ($res >= 0) {
+	print "  Added to catalog: $mname\n" if ($opt_verbose);
+	$added++;
+    } else {
+	# Already in catalog (-10) - that's fine for sync
+	$skipped++ unless ($opt_sync);
+    }
+
+    # Set groups for member
+    if (@mgroups > 0) {
+	$res = set_member_groups($zone_id, $catalog_zone_id, \@mgroups);
+	if ($res < 0) {
+	    print STDERR "WARNING: cannot set groups for '$mname' (error=$res)\n";
+	} elsif ($opt_verbose) {
+	    print "    Groups: " . join(', ', @mgroups) . "\n";
+	}
+    }
+
+    # Assign to Sauron group if specified
+    if ($opt_group && $gid > 0) {
+	# Only set group for newly created zones (type S)
+	my %zrec;
+	if (get_zone($zone_id, \%zrec) == 0 && $zrec{type} eq 'S') {
+	    # Check if zone already belongs to a group
+	    my @gq;
+	    db_query("SELECT grp FROM zones WHERE id=$zone_id", \@gq);
+	    if (@gq > 0 && (!$gq[0][0] || $gq[0][0] < 1)) {
+		db_exec("UPDATE zones SET grp=$gid WHERE id=$zone_id");
+	    }
+	}
+    }
+}
+
+##############################
+# Commit
+
+unless ($opt_notransaction || $opt_dryrun) {
+    db_ignore_begin_and_commit(0);
+    fatal("cannot commit changes to database!") if (db_commit() < 0);
+}
+
+##############################
+# Summary
+
+print "\nImport summary for catalog zone: $catalogname\n";
+print "  Members in catalog: $member_count\n";
+print "  Added:   $added\n";
+print "  Skipped: $skipped\n" if ($skipped > 0);
+print "  Failed:  $failed\n" if ($failed > 0);
+print "  Removed: $removed\n" if ($removed > 0);
+print "  (dry-run mode - no changes made)\n" if ($opt_dryrun);
+
+exit($failed > 0 ? 1 : 0);
+
+# eof

--- a/import-catalog-zone
+++ b/import-catalog-zone
@@ -103,7 +103,9 @@ if ($opt_file) {
 #   group.<uuid>.zones.catalog.<origin>  TXT "<group-name>"
 
 # Verify catalog version
-$version_key = "version.$origin";
+# Sauron generator writes 'version.catalog' relative to zone origin, so
+# after FQDN expansion it becomes 'version.catalog.<origin>'.
+$version_key = "version.catalog.$origin";
 if ($zonedata{$version_key} && @{$zonedata{$version_key}{TXT}} > 0) {
     $catver = $zonedata{$version_key}{TXT}[0];
     $catver =~ s/^"(.*)"$/$1/;  # strip quotes if present
@@ -115,8 +117,10 @@ if ($zonedata{$version_key} && @{$zonedata{$version_key}{TXT}} > 0) {
 }
 
 # Extract member zones and group assignments
+# Sauron generator uses 'uuid-xxx.zones.catalog' and 'group.uuid-xxx.zones.catalog'
+# relative to zone origin, expanding to '*.zones.catalog.<origin>'.
 %members = ();  # uuid => { name => 'zone.name', groups => ['g1', ...] }
-$zones_suffix = "zones.$origin";
+$zones_suffix = "zones.catalog.$origin";
 
 foreach $domain (keys %zonedata) {
     my $rec = $zonedata{$domain};

--- a/import-catalog-zone
+++ b/import-catalog-zone
@@ -15,6 +15,7 @@
 #
 require 5;
 use Getopt::Long;
+use Net::DNS;
 use Sauron::DB;
 use Sauron::Util;
 use Sauron::UtilZone;
@@ -28,7 +29,8 @@ load_config();
 ##############################
 
 GetOptions("help|h", "verbose|v", "dryrun|dry-run|n", "sync",
-	   "nameserver=s", "file=s", "catalog-only", "group=s",
+	   "nameserver=s", "axfr-zone=s", "axfr-port=i",
+	   "catalog-only", "group=s",
 	   "notransaction");
 
 $opt_dryrun = $opt_dryrun || 0;
@@ -36,12 +38,13 @@ $opt_verbose = ($opt_verbose ? 1 : 0);
 $opt_sync = $opt_sync || 0;
 
 if ($opt_help || @ARGV < 2) {
-    print "syntax: $0 [options] <servername> <catalog-zone-name>\n\n";
+    print "syntax: $0 [options] <servername> <catalog-zone> [<zone file>]\n\n";
     print "Imports an external catalog zone (RFC 9432) into Sauron as a\n";
     print "shadow catalog zone (type C, catalog_only).\n\n";
     print "options:\n",
-	"\t--nameserver=<ns>\tuse this nameserver for AXFR transfer\n",
-	"\t--file=<path>\t\timport from zone file instead of AXFR\n",
+	"\t--nameserver=<spec>\tAXFR source: <host>[:port][/zone]\n",
+	"\t--axfr-zone=<zone>\toverride zone name used for AXFR\n",
+	"\t--axfr-port=<port>\toverride AXFR TCP port\n",
 	"\t--group=<name>\t\tassign imported member zones to this group\n",
 	"\t--catalog-only\t\tmark shadow catalog zone as catalog_only\n",
 	"\t\t\t\t(skip named.conf and zone file generation)\n",
@@ -50,11 +53,28 @@ if ($opt_help || @ARGV < 2) {
 	"\t--verbose\t\tdisplay detailed progress\n",
 	"\t--notransaction\t\tdo not use transactions\n",
 	"\t--help\t\t\tdisplay this help\n\n";
+    print "examples:\n",
+	"\t$0 myserver catalog.example.com /tmp/catalog.zone\n",
+	"\t$0 --nameserver=ns1.example.net:5353 myserver catalog.example.com\n\n";
     exit(($opt_help ? 0 : 1));
 }
 
 $servername = shift;
 $catalogname = shift;
+$zonefile = shift;  # optional third positional arg
+$axfr_zone = '';
+$axfr_ns = '';
+$axfr_port = 53;
+
+# Zone file can come from positional arg or --nameserver for AXFR
+if ($zonefile) {
+    fatal("cannot specify both <zone file> and --nameserver")
+	if ($opt_nameserver);
+    $opt_file = $zonefile;
+}
+
+fatal("one of <zone file> or --nameserver must be specified")
+    unless ($opt_file || $opt_nameserver);
 
 $user = (getpwuid($<))[0];
 set_muser($user);
@@ -64,10 +84,25 @@ db_connect();
 $serverid = get_server_id($servername);
 fatal("cannot find server: $servername") unless ($serverid > 0);
 
-# Validate nameserver option
+# Validate AXFR source options
 if ($opt_nameserver) {
-    fatal("invalid nameserver: $opt_nameserver")
-	unless (valid_domainname($opt_nameserver) || is_cidr($opt_nameserver));
+    ($axfr_ns, $axfr_port, $axfr_zone) = parse_nameserver_spec($opt_nameserver);
+
+    fatal("invalid nameserver: $axfr_ns")
+	unless (valid_domainname($axfr_ns) || is_cidr($axfr_ns)
+		|| $axfr_ns =~ /^[0-9a-fA-F:]+$/);
+
+    if ($opt_axfr_port) {
+	fatal("invalid --axfr-port value: $opt_axfr_port")
+	    unless ($opt_axfr_port =~ /^\d+$/ && $opt_axfr_port > 0 && $opt_axfr_port < 65536);
+	$axfr_port = $opt_axfr_port;
+    }
+
+    if ($opt_axfr_zone) {
+	fatal("--axfr-zone and --nameserver=<host>[:port]/<zone> cannot both define AXFR zone")
+	    if ($axfr_zone ne '');
+	$axfr_zone = $opt_axfr_zone;
+    }
 }
 
 # Validate catalog zone name
@@ -75,6 +110,13 @@ fatal("invalid catalog zone name: $catalogname")
     unless (valid_domainname($catalogname));
 $catalogname =~ s/\.$//;
 $origin = $catalogname . '.';
+
+if ($opt_nameserver) {
+	$axfr_zone = $catalogname unless ($axfr_zone);
+	$axfr_zone =~ s/\.$//;
+	fatal("invalid AXFR zone name: $axfr_zone")
+	unless (valid_domainname($axfr_zone));
+}
 
 # Validate group if specified
 if ($opt_group) {
@@ -91,7 +133,8 @@ if ($opt_file) {
     fatal("cannot read zone file: $opt_file") unless (-r $opt_file);
     process_zonefile($opt_file, $catalogname, \%zonedata, 0);
 } else {
-    process_zonedns($catalogname, \%zonedata, $opt_nameserver, $opt_verbose);
+	print "AXFR source: $axfr_ns:$axfr_port zone=$axfr_zone\n" if ($opt_verbose);
+	process_zonedns_axfr($axfr_zone, \%zonedata, $axfr_ns, $axfr_port, $opt_verbose);
 }
 
 ##############################
@@ -444,5 +487,155 @@ print "  Removed: $removed\n" if ($removed > 0);
 print "  (dry-run mode - no changes made)\n" if ($opt_dryrun);
 
 exit($failed > 0 ? 1 : 0);
+
+
+sub parse_nameserver_spec($) {
+    my ($spec) = @_;
+    my ($host, $port, $zone);
+
+    $host = $spec;
+    $port = 53;
+    $zone = '';
+
+    if ($host =~ /^(.+)\/(\S+)$/) {
+	$host = $1;
+	$zone = $2;
+    }
+
+    # Support [ipv6]:port and host:port
+    if ($host =~ /^\[([^\]]+)\]:(\d+)$/) {
+	$host = $1;
+	$port = $2;
+    }
+    elsif ($host =~ /^([^:]+):(\d+)$/) {
+	$host = $1;
+	$port = $2;
+    }
+
+    return ($host, $port, $zone);
+}
+
+
+sub process_zonedns_axfr($$$$$) {
+    my ($zone, $data, $nameserver, $port, $verbose) = @_;
+    my (@zonedata, $rr, $domain, $type, $class, $ttl, $c, $rec, $tmp);
+    my $resolver = Net::DNS::Resolver->new;
+    my $ucount = 0;
+    my $origin = $zone;
+
+    $origin .= '.' unless ($origin =~ /\.$/);
+
+    $resolver->nameservers($nameserver) if ($nameserver);
+    $resolver->port($port) if ($port);
+
+    print "Zone transfer...\n" if ($verbose);
+    @zonedata = $resolver->axfr($zone);
+    fatal("zone transfer failed: " . $resolver->errorstring)
+	if (@zonedata < 1);
+
+    foreach $rr (@zonedata) {
+	$domain = $rr->name . '.';
+	$type = $rr->type;
+	$class = $rr->class;
+	$ttl = $rr->ttl;
+
+	next unless ($class eq 'IN');
+	unless ($type =~ /^(SOA|A|AAAA|PTR|CNAME|MX|NS|TXT|HINFO|SRV|WKS|CAA|DS|SSHFP|TLSA|NAPTR)$/) {
+	    $ucount++;
+	    print "Skipping: " . $rr->string . "\n" if ($verbose);
+	    next;
+	}
+
+	unless ($data->{$domain}) {
+	    $data->{$domain} = {
+		TTL => $ttl,
+		CLASS => $class,
+		SOA => '',
+		A => [],
+		AAAA => [],
+		PTR => [],
+		CNAME => '',
+		MX => [],
+		NS => [],
+		TXT => [],
+		HINFO => ['',''],
+		CAA => [],
+		DS => [],
+		SSHFP => [],
+		TLSA => [],
+		NAPTR => [],
+		WKS => [],
+		SRV => []
+	      };
+	}
+
+	$rec = $data->{$domain};
+
+	if ($type eq 'A') {
+	    push @{$rec->{A}}, $rr->address;
+	}
+	elsif ($type eq 'AAAA') {
+	    push @{$rec->{AAAA}}, lc($rr->address);
+	}
+	elsif ($type eq 'SOA') {
+	    $rec->{SOA} = join(" ",($rr->mname,$rr->rname,$rr->serial,
+				    $rr->refresh,$rr->retry,
+				    $rr->expire,$rr->minimum));
+	}
+	elsif ($type eq 'PTR') {
+	    push @{$rec->{PTR}}, $rr->ptrdname;
+	}
+	elsif ($type eq 'CNAME') {
+	    $rec->{CNAME} = $rr->cname . '.';
+	}
+	elsif ($type eq 'MX') {
+	    $tmp = $rr->exchange . '.';
+	    $tmp = '$DOMAIN'
+		if (remove_origin($tmp,$origin) eq
+		    remove_origin($domain,$origin));
+
+	    push @{$rec->{MX}}, $rr->preference . " " . $tmp;
+	}
+	elsif ($type eq 'NS') {
+	    push @{$rec->{NS}}, $rr->nsdname . '.';
+	}
+	elsif ($type eq 'TXT') {
+	    push @{$rec->{TXT}}, $rr->txtdata;
+	}
+	elsif ($type eq 'WKS') {
+	   # ignore...
+	}
+	elsif ($type eq 'HINFO') {
+	    $rec->{HINFO}[0] = $rr->cpu;
+	    $rec->{HINFO}[1] = $rr->os;
+	}
+	elsif ($type eq 'CAA') {
+	    push @{$rec->{CAA}}, join(" ",($rr->flags,$rr->tag,$rr->value));
+	}
+	elsif ($type eq 'DS') {
+	    push @{$rec->{DS}}, join(" ",($rr->keytag,$rr->algorithm,$rr->digtype,$rr->digest));
+	}
+	elsif ($type eq 'SSHFP') {
+	    push @{$rec->{SSHFP}}, join(" ",($rr->flags,$rr->tag,$rr->value));
+	}
+	elsif ($type eq 'TLSA') {
+	    push @{$rec->{TLSA}}, join(" ",($rr->usage,$rr->selector,$rr->matchingtype,$rr->cert));
+	}
+	elsif ($type eq 'NAPTR') {
+	    push @{$rec->{NAPTR}}, join(" ",($rr->order,$rr->preference,
+					   uc($rr->flags),$rr->service,
+					   $rr->regexp,$rr->replacement));
+	}
+	elsif ($type eq 'SRV') {
+	    push @{$rec->{SRV}}, join(" ",($rr->priority,$rr->weight,
+					 $rr->port,$rr->target . '.'));
+	}
+
+	$c++;
+    }
+
+    print "Processed $c records (ignored $ucount records)\n"
+	if ($verbose);
+}
 
 # eof

--- a/import-catalog-zone
+++ b/import-catalog-zone
@@ -167,7 +167,10 @@ if ($opt_verbose) {
 
 fatal("no member zones found in catalog zone") if ($member_count == 0);
 
-exit(0) if ($opt_dryrun && !$opt_sync);
+if ($opt_dryrun && !$opt_sync) {
+    print "(dry-run mode - no changes will be made)\n";
+    exit(0);
+}
 
 ##############################
 # Database operations

--- a/import-catalog-zone
+++ b/import-catalog-zone
@@ -30,7 +30,7 @@ load_config();
 
 GetOptions("help|h", "verbose|v", "dryrun|dry-run|n", "sync",
 	   "nameserver=s", "axfr-zone=s", "axfr-port=i",
-	   "catalog-only", "group=s",
+	   "catalog-only", "group=s", "ignore-groups",
 	   "notransaction");
 
 $opt_dryrun = $opt_dryrun || 0;
@@ -46,6 +46,8 @@ if ($opt_help || @ARGV < 2) {
 	"\t--axfr-zone=<zone>\toverride zone name used for AXFR\n",
 	"\t--axfr-port=<port>\toverride AXFR TCP port\n",
 	"\t--group=<name>\t\tassign imported member zones to this group\n",
+	"\t\t\t\t(group is auto-created if it does not exist)\n",
+	"\t--ignore-groups\t\tignore RFC 9432 group TXT records from import\n",
 	"\t--catalog-only\t\tmark shadow catalog zone as catalog_only\n",
 	"\t\t\t\t(skip named.conf and zone file generation)\n",
 	"\t--sync\t\t\tsynchronize: add new members, remove stale ones\n",
@@ -118,10 +120,23 @@ if ($opt_nameserver) {
 	unless (valid_domainname($axfr_zone));
 }
 
-# Validate group if specified
+# Validate group if specified - auto-create if missing
 if ($opt_group) {
     $gid = get_group_by_name($serverid, $opt_group);
-    fatal("cannot find group: $opt_group") unless ($gid > 0);
+    if ($gid < 0) {
+	print "Creating group '$opt_group' for server '$servername'\n"
+	    if ($opt_verbose);
+	unless ($opt_dryrun) {
+	    $gid = add_group({server => $serverid, name => $opt_group,
+			       type => 0, comment => "Created by import-catalog-zone",
+			       dhcp => [], dhcp6 => [], printer => []});
+	    fatal("cannot create group '$opt_group' (error=$gid)") if ($gid < 0);
+	    print "  Created group '$opt_group' (id=$gid)\n" if ($opt_verbose);
+	} else {
+	    print "[dry-run] Would create group: $opt_group\n";
+	    $gid = -999;
+	}
+    }
 }
 
 ##############################
@@ -137,6 +152,9 @@ if ($opt_file) {
 	process_zonedns_axfr($axfr_zone, \%zonedata, $axfr_ns, $axfr_port, $opt_verbose);
 }
 
+$source_origin = detect_catalog_origin(\%zonedata, $axfr_zone, $catalogname);
+print "Detected source catalog origin: $source_origin\n" if ($opt_verbose);
+
 ##############################
 # Parse catalog zone contents (RFC 9432)
 #
@@ -148,7 +166,7 @@ if ($opt_file) {
 # Verify catalog version
 # Sauron generator writes 'version.catalog' relative to zone origin, so
 # after FQDN expansion it becomes 'version.catalog.<origin>'.
-$version_key = "version.catalog.$origin";
+$version_key = "version.catalog.$source_origin";
 if ($zonedata{$version_key} && @{$zonedata{$version_key}{TXT}} > 0) {
     $catver = $zonedata{$version_key}{TXT}[0];
     $catver =~ s/^"(.*)"$/$1/;  # strip quotes if present
@@ -163,7 +181,7 @@ if ($zonedata{$version_key} && @{$zonedata{$version_key}{TXT}} > 0) {
 # Sauron generator uses 'uuid-xxx.zones.catalog' and 'group.uuid-xxx.zones.catalog'
 # relative to zone origin, expanding to '*.zones.catalog.<origin>'.
 %members = ();  # uuid => { name => 'zone.name', groups => ['g1', ...] }
-$zones_suffix = "zones.catalog.$origin";
+$zones_suffix = "zones.catalog.$source_origin";
 
 foreach $domain (keys %zonedata) {
     my $rec = $zonedata{$domain};
@@ -182,7 +200,8 @@ foreach $domain (keys %zonedata) {
 
     # Match group TXT records: group.<uuid>.zones.catalog.<origin>
     # Format: group.<uuid>.zones.catalog.<origin> TXT "<group-name>"
-    if ($domain =~ /^group\.([^.]+)\.\Q$zones_suffix\E$/i && @{$rec->{TXT}} > 0) {
+    if (!$opt_ignore_groups &&
+	$domain =~ /^group\.([^.]+)\.\Q$zones_suffix\E$/i && @{$rec->{TXT}} > 0) {
 	my $uuid = $1;
 	$members{$uuid} = { name => '', groups => [] }
 	    unless ($members{$uuid});
@@ -243,7 +262,7 @@ if ($catalog_zone_id > 0) {
 	print "[dry-run] Would create catalog zone: $catalogname\n";
 	$catalog_zone_id = -999;  # placeholder
     } else {
-	my $soa_rec = $zonedata{$origin};
+	my $soa_rec = $zonedata{$source_origin};
 	fatal("no SOA record in catalog zone") unless ($soa_rec && $soa_rec->{SOA});
 
 	my @soa = split(/\s+/, $soa_rec->{SOA});
@@ -293,7 +312,7 @@ if ($catalog_zone_id > 0) {
 
 # Ensure group definitions exist in the shadow catalog
 %known_groups = ();
-unless ($opt_dryrun) {
+unless ($opt_dryrun || $opt_ignore_groups) {
     # Collect all group names from imported members
     my %needed_groups;
     foreach my $uuid (@member_uuids) {
@@ -443,7 +462,7 @@ foreach my $uuid (sort { $members{$a}{name} cmp $members{$b}{name} } @member_uui
     }
 
     # Set groups for member
-    if (@mgroups > 0) {
+    if (@mgroups > 0 && !$opt_ignore_groups) {
 	$res = set_member_groups($zone_id, $catalog_zone_id, \@mgroups);
 	if ($res < 0) {
 	    print STDERR "WARNING: cannot set groups for '$mname' (error=$res)\n";
@@ -452,17 +471,20 @@ foreach my $uuid (sort { $members{$a}{name} cmp $members{$b}{name} } @member_uui
 	}
     }
 
-    # Assign to Sauron group if specified
+    # Assign to Sauron group if specified (best-effort)
     if ($opt_group && $gid > 0) {
-	# Only set group for newly created zones (type S)
-	my %zrec;
-	if (get_zone($zone_id, \%zrec) == 0 && $zrec{type} eq 'S') {
-	    # Check if zone already belongs to a group
-	    my @gq;
-	    db_query("SELECT grp FROM zones WHERE id=$zone_id", \@gq);
-	    if (@gq > 0 && (!$gq[0][0] || $gq[0][0] < 1)) {
-		db_exec("UPDATE zones SET grp=$gid WHERE id=$zone_id");
+	# Some schemas do not have zones.grp. Use apex host record when present.
+	my @hq;
+	db_query("SELECT id, grp FROM hosts " .
+		 "WHERE zone=$zone_id AND domain='\@' ORDER BY id LIMIT 1", \@hq);
+	if (@hq > 0) {
+	    my $host_id = $hq[0][0];
+	    my $cur_grp = $hq[0][1];
+	    if (!$cur_grp || $cur_grp < 1) {
+		db_exec("UPDATE hosts SET grp=$gid WHERE id=$host_id");
 	    }
+	} elsif ($opt_verbose) {
+	    print "    Note: no apex host record for '$mname'; group assignment skipped\n";
 	}
     }
 }
@@ -513,6 +535,49 @@ sub parse_nameserver_spec($) {
     }
 
     return ($host, $port, $zone);
+}
+
+
+sub detect_catalog_origin($$$) {
+	my ($zonedata, $preferred_zone, $fallback_zone) = @_;
+	my (@soa_candidates, @version_candidates, $candidate);
+
+	if ($preferred_zone) {
+	$candidate = $preferred_zone;
+	$candidate .= '.' unless ($candidate =~ /\.$/);
+	return $candidate if ($zonedata->{$candidate} && $zonedata->{$candidate}{SOA});
+	}
+
+	if ($fallback_zone) {
+	$candidate = $fallback_zone;
+	$candidate .= '.' unless ($candidate =~ /\.$/);
+	return $candidate if ($zonedata->{$candidate} && $zonedata->{$candidate}{SOA});
+	}
+
+	@soa_candidates = sort grep {
+	$zonedata->{$_} && $zonedata->{$_}{SOA} && $zonedata->{$_}{SOA} ne ''
+	} keys %{$zonedata};
+	return $soa_candidates[0] if (@soa_candidates == 1);
+
+	@version_candidates = sort map {
+	/^version\.catalog\.(.+)$/ ? $1 : ()
+	} keys %{$zonedata};
+	return $version_candidates[0] if (@version_candidates == 1);
+
+	fatal("cannot determine source catalog origin from imported data")
+		if (!@soa_candidates && !@version_candidates);
+
+	if (@soa_candidates > 1) {
+	fatal("multiple SOA origins found in imported data: " . join(', ', @soa_candidates));
+	}
+
+	if (@version_candidates > 1) {
+	fatal("multiple catalog version origins found in imported data: " .
+	      join(', ', @version_candidates));
+	}
+
+	return $soa_candidates[0] if (@soa_candidates > 0);
+	return $version_candidates[0];
 }
 
 

--- a/init/tables.sql
+++ b/init/tables.sql
@@ -48,8 +48,10 @@ CREATE TABLE zones ( /* zone table; contains zones */
 
        active	   BOOL DEFAULT true,
        dummy	   BOOL DEFAULT false,
+       catalog_only BOOL DEFAULT false,
        type	   CHAR(1) NOT NULL, /* (H)int, (M)aster, (S)lave, 
-				        (F)orward, ... */
+				        (F)orward, (C)atalog,
+					(A)ggregate catalog */
        reverse	   BOOL DEFAULT false, /* true for reverse (arpa) zones */
        noreverse   BOOL DEFAULT false, /* if true, zone not used in reverse
 				          map generation */

--- a/sauron
+++ b/sauron
@@ -1740,7 +1740,7 @@ sub make_dns() {
             if ($seen_names{$lc_name}) {
               push @conflicts,
                 "  '$mzone_name' from '$src_name' (prio=$prio) " .
-                "overridden by '$seen_names{$lc_name}'";
+                "skipped; $seen_names{$lc_name} has higher precedence (lower priority)";
               next;
             }
             $seen_names{$lc_name} = "$src_name (prio=$prio)";

--- a/sauron
+++ b/sauron
@@ -31,8 +31,8 @@ $printer_conf=0;
 
 %yes_no_enum = (D=>'',Y=>'yes',N=>'no');
 %check_names_enum = (D=>'',W=>'warn',F=>'fail',I=>'ignore');
-# Catalog zones (C) are configured as type master in BIND (RFC 9432)
-%zone_type_enum = (M=>'master',S=>'slave',H=>'hint',F=>'forward',C=>'master');
+# Catalog zones (C) and aggregate catalog zones (A) are configured as type master in BIND (RFC 9432)
+%zone_type_enum = (M=>'master',S=>'slave',H=>'hint',F=>'forward',C=>'master',A=>'master');
 %forward_enum = (D=>'', O=>'only', F=>'first');
 %algorithm_enum = (157=>'hmac-md5');
 
@@ -392,6 +392,13 @@ sub make_dns() {
 
     $type=$zone_type_enum{$zone{type}};
     fatal("unknown zone type '$zone{type}'!") unless ($type ne '');
+
+    # Skip catalog-only zones - they exist only as catalog members
+    if ($zone{'catalog_only'} eq 't') {
+      print "Skipping catalog-only zone: $zonename\n" if ($opt_verbose);
+      next;
+    }
+
     if ($loopcounter >= $normalzones) {
       $subtype=$type;
       # process zones from master server
@@ -491,7 +498,7 @@ sub make_dns() {
     }
 
     # Catalog zones are treated as master zones for file generation (RFC 9432)
-    next unless ($type eq 'master' || $zone{type} eq 'C');
+    next unless ($type eq 'master' || $zone{type} eq 'C' || $zone{type} eq 'A');
 
     if ($zone{'dummy'} eq 't') {
       print "Skipping zone creation for dummy zone: $zonename\n";
@@ -573,7 +580,7 @@ sub make_dns() {
     fatal("no hostmaster defined either in server nor zone record for: " .
           "$zonename") if ($hostmaster eq '');
     fatal("server hostname not defined!") if ($hostname eq '');
-    fatal("no TTL defined!") unless ($TTL > 0 || $zone{type} eq 'C');
+    fatal("no TTL defined!") unless ($TTL > 0 || $zone{type} eq 'C' || $zone{type} eq 'A');
     if ($bind_conf) {
       print ZONEFILE '$TTL ' . "$TTL\t; default TTL for this zone\n;\n";
       print ZONEFILE '$ORIGIN ' . "$zonename.\n;\n";
@@ -606,8 +613,8 @@ sub make_dns() {
       }
     }
 
-    if ($zone{type} eq 'C' || !$has_ns) {
-      # Catalog zone or no NS records - add placeholder NS record
+    if ($zone{type} eq 'C' || $zone{type} eq 'A' || !$has_ns) {
+      # Catalog/aggregate zone or no NS records - add placeholder NS record
       printf ZONEFILE $ZFORMAT, '',$ttl,$class,'NS','invalid.'
         if ($bind_conf);
       printf TINYDNSFILE "&$zonename\:\:invalid.\:$ttl\:\:\n"
@@ -1697,6 +1704,68 @@ sub make_dns() {
       } else {
         print ZONEFILE ";\n; Catalog zone (no members currently)\n;\n" if ($bind_conf);
         print ZONEFILE "version.catalog\t$ttl\tIN\tTXT\t\"2\"\n" if ($bind_conf);
+      }
+    }
+
+    # Aggregate catalog zone - merge members from source catalog zones (RFC 9432)
+    if ($zone{type} eq 'A' && $bind_conf) {
+      my (@comps, %seen_names, @conflicts);
+
+      # Load source catalog zones ordered by priority
+      db_query("SELECT cc.source_zone_id, z.name, cc.priority " .
+               "FROM catalog_compositions cc " .
+               "JOIN zones z ON cc.source_zone_id = z.id " .
+               "WHERE cc.composite_zone_id = $zoneid " .
+               "ORDER BY cc.priority ASC, z.name ASC", \@comps);
+
+      if (@comps > 0) {
+        print ZONEFILE ";\n; Aggregate catalog zone members (RFC 9432)\n;\n";
+        print ZONEFILE "version.catalog\t$ttl\tIN\tTXT\t\"2\"\n";
+
+        for my $comp (@comps) {
+          my ($src_id, $src_name, $prio) = @$comp;
+          my $src_rec = {};
+          get_zone_catalog_members($src_id, $src_rec);
+
+          print ZONEFILE ";\n; Source: $src_name (priority=$prio)\n;\n";
+
+          next unless ($src_rec->{count} > 0);
+          for $i (0 .. $#{$src_rec->{members}}) {
+            my $mzone_name = $src_rec->{members}[$i][1];
+            my $mzone_id   = $src_rec->{members}[$i][0];
+            my $mgroups    = $src_rec->{members}[$i][7];
+            $mzone_name =~ s/\.\.?$//;
+
+            my $lc_name = lc($mzone_name);
+            if ($seen_names{$lc_name}) {
+              push @conflicts,
+                "  '$mzone_name' from '$src_name' (prio=$prio) " .
+                "overridden by '$seen_names{$lc_name}'";
+              next;
+            }
+            $seen_names{$lc_name} = "$src_name (prio=$prio)";
+
+            printf ZONEFILE $ZFORMAT,
+                "uuid-$mzone_id.zones.catalog",
+                $ttl, 'IN', 'PTR', "$mzone_name.";
+
+            if (ref($mgroups) eq 'ARRAY') {
+              for my $grp (@{$mgroups}) {
+                printf ZONEFILE $ZFORMAT,
+                    "group.uuid-$mzone_id.zones.catalog",
+                    $ttl, 'IN', 'TXT', "\"$grp\"";
+              }
+            }
+          }
+        }
+
+        if (@conflicts) {
+          print "CONFLICTS in aggregate zone '$zonename':\n";
+          for my $c (@conflicts) { print "$c\n"; }
+        }
+      } else {
+        print ZONEFILE ";\n; Aggregate catalog zone (no source catalogs configured)\n;\n";
+        print ZONEFILE "version.catalog\t$ttl\tIN\tTXT\t\"2\"\n";
       }
     }
 

--- a/sql/catalog_compositions.sql
+++ b/sql/catalog_compositions.sql
@@ -1,0 +1,42 @@
+/* catalog_compositions table creation
+ *
+ * table to store composition of aggregate catalog zones (type 'A')
+ * Each aggregate catalog zone is composed of one or more source
+ * catalog zones (type 'C') with a priority for conflict resolution.
+ *
+ * Lower priority number = higher precedence when the same member zone
+ * appears in multiple source catalogs.
+ *
+ * $Id:$
+ */
+
+/** This table stores the composition of aggregate catalog zones. **/
+
+CREATE TABLE catalog_compositions (
+       id                SERIAL PRIMARY KEY,    /* unique ID */
+       composite_zone_id INT4 NOT NULL,         /* ptr to zones table (type='A')
+                                                   -->zones.id */
+       source_zone_id    INT4 NOT NULL,         /* ptr to zones table (type='C')
+                                                   -->zones.id */
+       priority          INT4 NOT NULL DEFAULT 100,
+                                                /* lower number = higher priority
+                                                   in conflict resolution */
+
+       /* Constraints */
+       CONSTRAINT catalog_compositions_composite_fk
+           FOREIGN KEY (composite_zone_id) REFERENCES zones(id) ON DELETE CASCADE,
+       CONSTRAINT catalog_compositions_source_fk
+           FOREIGN KEY (source_zone_id) REFERENCES zones(id) ON DELETE CASCADE,
+       CONSTRAINT catalog_compositions_unique
+           UNIQUE (composite_zone_id, source_zone_id),
+       CONSTRAINT catalog_compositions_priority
+           CHECK (priority > 0),
+       CONSTRAINT catalog_compositions_no_self
+           CHECK (composite_zone_id != source_zone_id)
+);
+
+/* Indexes for fast lookups */
+CREATE INDEX idx_catalog_compositions_composite
+    ON catalog_compositions(composite_zone_id);
+CREATE INDEX idx_catalog_compositions_priority
+    ON catalog_compositions(composite_zone_id, priority);

--- a/sql/dbconvert_1.7to1.8
+++ b/sql/dbconvert_1.7to1.8
@@ -197,6 +197,51 @@ CREATE INDEX idx_catalog_group_defs_catalog ON catalog_group_defs(catalog_zone_i
 
 ALTER TABLE catalog_group_defs OWNER TO sauron;
 
+
+/* Add catalog_only flag to zones table */
+
+ALTER TABLE zones ADD COLUMN catalog_only BOOL DEFAULT false;
+COMMENT ON COLUMN zones.catalog_only IS 'if true, zone is not generated to named.conf or zone file; exists only as a catalog member source';
+
+
+/** This table stores the composition of aggregate catalog zones (type A).
+    Each aggregate catalog zone is composed of one or more source
+    catalog zones (type C) with a priority for conflict resolution.
+    Lower priority number = higher precedence when the same member zone
+    appears in multiple source catalogs. **/
+
+CREATE TABLE catalog_compositions (
+       id                SERIAL PRIMARY KEY,    /* unique ID */
+       composite_zone_id INT4 NOT NULL,         /* ptr to zones table (type='A')
+                                                   -->zones.id */
+       source_zone_id    INT4 NOT NULL,         /* ptr to zones table (type='C')
+                                                   -->zones.id */
+       priority          INT4 NOT NULL DEFAULT 100,
+                                                /* lower number = higher priority
+                                                   in conflict resolution */
+
+       /* Constraints */
+       CONSTRAINT catalog_compositions_composite_fk
+           FOREIGN KEY (composite_zone_id) REFERENCES zones(id) ON DELETE CASCADE,
+       CONSTRAINT catalog_compositions_source_fk
+           FOREIGN KEY (source_zone_id) REFERENCES zones(id) ON DELETE CASCADE,
+       CONSTRAINT catalog_compositions_unique
+           UNIQUE (composite_zone_id, source_zone_id),
+       CONSTRAINT catalog_compositions_priority
+           CHECK (priority > 0),
+       CONSTRAINT catalog_compositions_no_self
+           CHECK (composite_zone_id != source_zone_id)
+);
+
+/* Indexes for fast lookups */
+CREATE INDEX idx_catalog_compositions_composite
+    ON catalog_compositions(composite_zone_id);
+CREATE INDEX idx_catalog_compositions_priority
+    ON catalog_compositions(composite_zone_id, priority);
+
+ALTER TABLE catalog_compositions OWNER TO sauron;
+
+
 /* set DB version */
 
 UPDATE settings SET value='1.8' where setting='dbversion';

--- a/sql/zones.sql
+++ b/sql/zones.sql
@@ -17,11 +17,16 @@ CREATE TABLE zones (
 					 (only active zones are included in
 					  named configuration) */
        dummy	   BOOL DEFAULT false, /* dummy zone flag */
+       catalog_only BOOL DEFAULT false, /* if true, zone is not generated
+					   to named.conf or zone file;
+					   exists only as a catalog member */
        type	   CHAR(1) NOT NULL, /* zone type:
 					(H)int, 
 					(M)aster, 
 					(S)lave, 
-				        (F)orward */
+				        (F)orward,
+					(C)atalog,
+					(A)ggregate catalog */
        reverse	   BOOL DEFAULT false, /* true for reverse (arpa) zones */
        noreverse   BOOL DEFAULT false, /* if true, zone not used in reverse
 				          map generation */

--- a/t/13-catalog-aggregate.t
+++ b/t/13-catalog-aggregate.t
@@ -351,7 +351,7 @@ subtest 'generate aggregate zone file' => sub {
     close($fh);
 
     # Verify version record
-    like($content, qr/version\.catalog\s+.*\tIN\tTXT\t"2"/,
+    like($content, qr/version\.catalog\s+.*\s+IN\s+TXT\s+"2"/,
          'contains version.catalog TXT "2"');
 
     # Verify members from catalog1
@@ -383,9 +383,9 @@ subtest 'generate aggregate zone file' => sub {
     # Find the uuid for shared's PTR line and check its group
     my $shared_zone_id = get_zone_id('shared.example.com', $serverid);
     if ($shared_zone_id > 0) {
-        like($content, qr/uuid-$shared_zone_id\.zones\.catalog\s+.*\tPTR\s+shared\.example\.com\./,
+        like($content, qr/uuid-$shared_zone_id\.zones\.catalog\s+.*\s+PTR\s+shared\.example\.com\./,
              'shared uses correct uuid in aggregate');
-        like($content, qr/group\.uuid-$shared_zone_id\.zones\.catalog\s+.*\tTXT\s+"shared-group"/,
+        like($content, qr/group\.uuid-$shared_zone_id\.zones\.catalog\s+.*\s+TXT\s+"shared-group"/,
              'shared group from catalog1 (priority 10) wins');
     }
 
@@ -595,7 +595,7 @@ subtest 'generate after priority swap - conflict winner changes' => sub {
     # With catalog1 at priority=1 (wins), shared's group should be from catalog1
     my $shared_zid = get_zone_id('shared.example.com', $serverid);
     if ($shared_zid > 0) {
-        like($content, qr/group\.uuid-$shared_zid\.zones\.catalog\s+.*\tTXT\s+"shared-group"/,
+        like($content, qr/group\.uuid-$shared_zid\.zones\.catalog\s+.*\s+TXT\s+"shared-group"/,
              'shared group from catalog1 (now priority=1) wins');
     }
 };

--- a/t/13-catalog-aggregate.t
+++ b/t/13-catalog-aggregate.t
@@ -1,0 +1,671 @@
+#!/usr/bin/perl
+# t/13-catalog-aggregate.t - Integration tests for catalog zone import,
+#                            aggregate zones, groups, and priority/conflict resolution
+#
+# Requires running PostgreSQL with initialized Sauron DB.
+# Skipped unless SAURON_TEST_DSN and SAURON_INSTALL_DIR are set.
+#
+# Test plan:
+#   1. Import external catalog zone from file (import-catalog-zone)
+#   2. Verify shadow catalog zone created with catalog_only flag
+#   3. Verify member zones parsed and added
+#   4. Verify RFC 9432 group assignments propagated
+#   5. Import second catalog zone (overlapping member)
+#   6. Create aggregate zone (type A) and compose from both sources
+#   7. Verify priority-based conflict resolution
+#   8. Generate aggregate zone file, verify merged output
+#   9. Verify sync mode (--sync) removes stale members
+#  10. BackEnd API unit tests for composition functions
+#
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/..";
+use Test::More;
+use File::Temp qw(tempdir);
+
+my $install_dir = $ENV{SAURON_INSTALL_DIR} || '';
+my $dsn         = $ENV{SAURON_TEST_DSN}    || '';
+
+unless ($dsn && $install_dir && -d $install_dir) {
+    plan skip_all => 'Set SAURON_TEST_DSN and SAURON_INSTALL_DIR for catalog aggregate tests';
+}
+
+# Ensure DB.pm symlink
+my $db_link = "$FindBin::Bin/../Sauron/DB.pm";
+unless (-e $db_link) {
+    symlink("DB-DBI.pm", $db_link) or die "Cannot create DB.pm symlink: $!";
+}
+
+# Globals needed by Sauron modules
+our $SAURON_DNSNAME_CHECK_LEVEL = 0;
+our %perms = (alevel => 0);
+our $DB_DSN      = $ENV{SAURON_TEST_DSN}      || '';
+our $DB_USER     = $ENV{SAURON_TEST_USER}     || '';
+our $DB_PASSWORD = $ENV{SAURON_TEST_PASSWORD} || '';
+
+use Sauron::DB;
+use Sauron::Util;
+use Sauron::BackEnd;
+
+my $testdata = "$FindBin::Bin/../test";
+my $server   = 'catalog-test';
+
+# =========================================================================
+# Setup: connect to DB and create test server
+# =========================================================================
+subtest 'setup: database connection' => sub {
+    my $ret = db_connect2();
+    is($ret, 1, 'db_connect2 succeeds') or BAIL_OUT('Cannot connect to database');
+};
+
+# Check if test server exists, create if not
+my $serverid;
+subtest 'setup: create test server' => sub {
+    $serverid = get_server_id($server);
+    if ($serverid > 0) {
+        pass("test server '$server' already exists (id=$serverid)");
+        return;
+    }
+
+    # Create minimal server for testing
+    my $res = db_exec("INSERT INTO servers (name, hostname, hostmaster, " .
+                      "refresh, retry, expire, minimum, ttl) " .
+                      "VALUES ('$server', 'ns1.catalog-test.example.com.', " .
+                      "'admin.catalog-test.example.com.', " .
+                      "3600, 900, 604800, 3600, 3600)");
+    ok($res >= 0, 'inserted test server') or BAIL_OUT("Cannot create test server: $res");
+
+    $serverid = get_server_id($server);
+    ok($serverid > 0, "test server created (id=$serverid)")
+        or BAIL_OUT("Cannot find test server after insert");
+};
+
+
+# =========================================================================
+# Test 1: Import catalog zone #1 from file
+# =========================================================================
+subtest 'import catalog zone #1' => sub {
+    my $zonefile = "$testdata/catalog1.example.com.zone";
+    plan skip_all => "Zone file not found: $zonefile" unless (-r $zonefile);
+
+    my $cmd = "$install_dir/import-catalog-zone --verbose --catalog-only " .
+              "--file=$zonefile $server catalog1.example.com 2>&1";
+    my $out = `$cmd`;
+    my $rc = $? >> 8;
+    is($rc, 0, 'import-catalog-zone exits 0') or diag($out);
+    like($out, qr/Found 3 member zones/, 'found 3 members in catalog1');
+};
+
+
+# =========================================================================
+# Test 2: Verify shadow catalog zone created with correct properties
+# =========================================================================
+my $cat1_id;
+subtest 'verify shadow catalog zone #1' => sub {
+    $cat1_id = get_zone_id('catalog1.example.com', $serverid);
+    ok($cat1_id > 0, 'catalog1 zone exists in DB') or return;
+
+    my %zone;
+    my $res = get_zone($cat1_id, \%zone);
+    is($res, 0, 'get_zone succeeds');
+    is($zone{type}, 'C', 'zone type is C (catalog)');
+    is($zone{catalog_only}, 't', 'catalog_only flag is set');
+    like($zone{comment}, qr/shadow/i, 'comment indicates shadow/imported zone');
+};
+
+
+# =========================================================================
+# Test 3: Verify member zones created and added to catalog
+# =========================================================================
+subtest 'verify catalog #1 members' => sub {
+    plan skip_all => 'catalog1 not created' unless ($cat1_id && $cat1_id > 0);
+
+    my $rec = {};
+    my $res = get_zone_catalog_members($cat1_id, $rec);
+    is($res, 0, 'get_zone_catalog_members succeeds');
+    is($rec->{count}, 3, 'catalog has 3 members');
+
+    # Build name lookup
+    my %members;
+    for my $m (@{$rec->{members}}) {
+        $members{lc($m->[1])} = $m;
+    }
+
+    ok(exists $members{'alpha.example.com'}, 'alpha.example.com is member');
+    ok(exists $members{'beta.example.com'}, 'beta.example.com is member');
+    ok(exists $members{'shared.example.com'}, 'shared.example.com is member');
+};
+
+
+# =========================================================================
+# Test 4: Verify RFC 9432 group assignments propagated
+# =========================================================================
+subtest 'verify catalog #1 group assignments' => sub {
+    plan skip_all => 'catalog1 not created' unless ($cat1_id && $cat1_id > 0);
+
+    my $rec = {};
+    get_zone_catalog_members($cat1_id, $rec);
+
+    my %member_groups;
+    for my $m (@{$rec->{members}}) {
+        $member_groups{lc($m->[1])} = $m->[7];  # groups arrayref at index 7
+    }
+
+    is_deeply($member_groups{'alpha.example.com'}, ['frontend'],
+              'alpha has group "frontend"');
+    is_deeply($member_groups{'beta.example.com'}, ['backend'],
+              'beta has group "backend"');
+    is_deeply($member_groups{'shared.example.com'}, ['shared-group'],
+              'shared has group "shared-group"');
+};
+
+
+# =========================================================================
+# Test 5: Verify group definitions were created
+# =========================================================================
+subtest 'verify catalog #1 group definitions' => sub {
+    plan skip_all => 'catalog1 not created' unless ($cat1_id && $cat1_id > 0);
+
+    my $grp_rec = {};
+    my $res = get_catalog_group_defs($cat1_id, $grp_rec);
+    is($res, 0, 'get_catalog_group_defs succeeds');
+    ok($grp_rec->{count} >= 3, 'at least 3 group definitions exist');
+
+    my %names = map { $_->[1] => 1 } @{$grp_rec->{groups}};
+    ok($names{'frontend'}, 'group "frontend" defined');
+    ok($names{'backend'}, 'group "backend" defined');
+    ok($names{'shared-group'}, 'group "shared-group" defined');
+};
+
+
+# =========================================================================
+# Test 6: Import catalog zone #2 (with overlapping member)
+# =========================================================================
+my $cat2_id;
+subtest 'import catalog zone #2' => sub {
+    my $zonefile = "$testdata/catalog2.example.com.zone";
+    plan skip_all => "Zone file not found: $zonefile" unless (-r $zonefile);
+
+    my $cmd = "$install_dir/import-catalog-zone --verbose --catalog-only " .
+              "--file=$zonefile $server catalog2.example.com 2>&1";
+    my $out = `$cmd`;
+    my $rc = $? >> 8;
+    is($rc, 0, 'import-catalog-zone exits 0') or diag($out);
+    like($out, qr/Found 3 member zones/, 'found 3 members in catalog2');
+
+    $cat2_id = get_zone_id('catalog2.example.com', $serverid);
+    ok($cat2_id > 0, 'catalog2 zone exists in DB');
+};
+
+
+# =========================================================================
+# Test 7: Verify catalog #2 members and overlapping zone handling
+# =========================================================================
+subtest 'verify catalog #2 members and overlap' => sub {
+    plan skip_all => 'catalog2 not created' unless ($cat2_id && $cat2_id > 0);
+
+    my $rec = {};
+    get_zone_catalog_members($cat2_id, $rec);
+
+    my %members;
+    for my $m (@{$rec->{members}}) {
+        $members{lc($m->[1])} = $m;
+    }
+
+    ok(exists $members{'gamma.example.com'}, 'gamma.example.com is member');
+    ok(exists $members{'delta.example.com'}, 'delta.example.com is member');
+
+    # shared.example.com was already in catalog1, should also be in catalog2
+    # (zone can belong to multiple catalogs)
+    ok(exists $members{'shared.example.com'}, 'shared.example.com is also in catalog2');
+
+    # Verify shared has different group in catalog2
+    my $shared_groups = $members{'shared.example.com'}[7];
+    is_deeply($shared_groups, ['overlap-group'],
+              'shared has group "overlap-group" in catalog2');
+};
+
+
+# =========================================================================
+# Test 8: BackEnd API - create aggregate zone (type A)
+# =========================================================================
+my $agg_id;
+subtest 'create aggregate zone (type A)' => sub {
+    plan skip_all => 'catalogs not created' unless ($cat1_id > 0 && $cat2_id > 0);
+
+    my %zonehash = (
+        server   => $serverid,
+        type     => 'A',
+        reverse  => 'false',
+        name     => 'aggregate.example.com',
+        serial   => '2024010101',
+        refresh  => 3600,
+        retry    => 900,
+        expire   => 604800,
+        minimum  => 0,
+        ttl      => 0,
+        comment  => 'Test aggregate catalog zone',
+        ns       => [[0, 'invalid.', '']],
+        mx       => [],
+        txt      => [],
+        ip       => [],
+        naptr    => [],
+    );
+
+    $agg_id = add_zone(\%zonehash);
+    ok($agg_id > 0, "aggregate zone created (id=$agg_id)") or return;
+
+    my %zone;
+    get_zone($agg_id, \%zone);
+    is($zone{type}, 'A', 'zone type is A (aggregate)');
+};
+
+
+# =========================================================================
+# Test 9: BackEnd API - add compositions with priorities
+# =========================================================================
+subtest 'add catalog compositions with priorities' => sub {
+    plan skip_all => 'aggregate zone not created' unless ($agg_id && $agg_id > 0);
+
+    # Add catalog1 with priority 10 (higher precedence)
+    my $res = add_catalog_composition($agg_id, $cat1_id, 10);
+    ok($res >= 0, 'added catalog1 with priority=10') or diag("error=$res");
+
+    # Add catalog2 with priority 20 (lower precedence)
+    $res = add_catalog_composition($agg_id, $cat2_id, 20);
+    ok($res >= 0, 'added catalog2 with priority=20') or diag("error=$res");
+
+    # Verify compositions stored correctly
+    my $comp_rec = {};
+    $res = get_catalog_compositions($agg_id, $comp_rec);
+    is($res, 0, 'get_catalog_compositions succeeds');
+    is($comp_rec->{count}, 2, 'aggregate has 2 source compositions');
+
+    # Verify ordering by priority ASC
+    # Columns: [id, source_zone_id, source_name, priority]
+    my @comps = @{$comp_rec->{compositions}};
+    is($comps[0][1], $cat1_id, 'first composition is catalog1 (priority 10)');
+    is($comps[0][3], 10, 'catalog1 priority is 10');
+    is($comps[1][1], $cat2_id, 'second composition is catalog2 (priority 20)');
+    is($comps[1][3], 20, 'catalog2 priority is 20');
+};
+
+
+# =========================================================================
+# Test 10: BackEnd API - duplicate composition rejected
+# =========================================================================
+subtest 'duplicate composition rejected' => sub {
+    plan skip_all => 'aggregate zone not created' unless ($agg_id && $agg_id > 0);
+
+    my $res = add_catalog_composition($agg_id, $cat1_id, 50);
+    is($res, -10, 'duplicate composition returns -10');
+};
+
+
+# =========================================================================
+# Test 11: BackEnd API - validate composition type checks
+# =========================================================================
+subtest 'composition type validation' => sub {
+    plan skip_all => 'aggregate zone not created' unless ($agg_id && $agg_id > 0);
+
+    # Cannot add non-C zone as source
+    my $alpha_id = get_zone_id('alpha.example.com', $serverid);
+    if ($alpha_id > 0) {
+        my $res = add_catalog_composition($agg_id, $alpha_id, 50);
+        ok($res < 0, 'non-catalog zone rejected as source') or diag("error=$res");
+    }
+
+    # Cannot add to non-A zone as composite
+    my $res = add_catalog_composition($cat1_id, $cat2_id, 50);
+    ok($res < 0, 'non-aggregate zone rejected as composite') or diag("error=$res");
+
+    # Self-reference rejected
+    $res = add_catalog_composition($agg_id, $agg_id, 50);
+    is($res, -2, 'self-reference rejected');
+};
+
+
+# =========================================================================
+# Test 12: Generate aggregate zone file and verify merged output
+# =========================================================================
+subtest 'generate aggregate zone file' => sub {
+    plan skip_all => 'aggregate zone not created' unless ($agg_id && $agg_id > 0);
+
+    my $gendir = tempdir(CLEANUP => 1);
+    my $cmd = "$install_dir/sauron --verbose --bind $server $gendir 2>&1";
+    my $out = `$cmd`;
+    my $rc = $? >> 8;
+    is($rc, 0, 'sauron --bind exits 0') or do { diag($out); return; };
+
+    # Find the aggregate zone file
+    my $aggfile = find_zone_file($gendir, 'aggregate.example.com');
+    ok($aggfile && -r $aggfile, 'aggregate zone file generated') or do {
+        diag("Generated files: " . `find $gendir -type f`);
+        return;
+    };
+
+    # Read zone file content
+    open(my $fh, '<', $aggfile) or do { fail("cannot read $aggfile"); return; };
+    my $content = do { local $/; <$fh> };
+    close($fh);
+
+    # Verify version record
+    like($content, qr/version\.catalog\s+.*\tIN\tTXT\t"2"/,
+         'contains version.catalog TXT "2"');
+
+    # Verify members from catalog1
+    like($content, qr/PTR\s+alpha\.example\.com\./,
+         'contains alpha.example.com PTR');
+    like($content, qr/PTR\s+beta\.example\.com\./,
+         'contains beta.example.com PTR');
+
+    # Verify members from catalog2
+    like($content, qr/PTR\s+gamma\.example\.com\./,
+         'contains gamma.example.com PTR');
+    like($content, qr/PTR\s+delta\.example\.com\./,
+         'contains delta.example.com PTR');
+
+    # Verify group TXT records present
+    like($content, qr/TXT\s+"frontend"/,
+         'contains group "frontend"');
+    like($content, qr/TXT\s+"backend"/,
+         'contains group "backend"');
+    like($content, qr/TXT\s+"monitoring"/,
+         'contains group "monitoring"');
+
+    # shared.example.com should appear only once (from catalog1, priority 10)
+    my @shared_ptrs = ($content =~ /PTR\s+shared\.example\.com\./g);
+    is(scalar @shared_ptrs, 1,
+       'shared.example.com appears exactly once (conflict resolved by priority)');
+
+    # The group for shared should be from catalog1 (priority 10 wins)
+    # Find the uuid for shared's PTR line and check its group
+    my $shared_zone_id = get_zone_id('shared.example.com', $serverid);
+    if ($shared_zone_id > 0) {
+        like($content, qr/uuid-$shared_zone_id\.zones\.catalog\s+.*\tPTR\s+shared\.example\.com\./,
+             'shared uses correct uuid in aggregate');
+        like($content, qr/group\.uuid-$shared_zone_id\.zones\.catalog\s+.*\tTXT\s+"shared-group"/,
+             'shared group from catalog1 (priority 10) wins');
+    }
+
+    # Verify priority source comments
+    like($content, qr/Source:.*catalog1.*priority=10/,
+         'catalog1 source comment with priority=10');
+    like($content, qr/Source:.*catalog2.*priority=20/,
+         'catalog2 source comment with priority=20');
+
+    # Verify conflict output on stdout
+    like($out, qr/CONFLICT/i,
+         'generator reports conflict for shared.example.com')
+        if ($out =~ /shared/i);
+};
+
+
+# =========================================================================
+# Test 13: Verify catalog_only zones are NOT generated
+# =========================================================================
+subtest 'catalog_only zones skipped in generation' => sub {
+    plan skip_all => 'catalogs not created' unless ($cat1_id > 0);
+
+    my $gendir = tempdir(CLEANUP => 1);
+    my $cmd = "$install_dir/sauron --verbose --bind $server $gendir 2>&1";
+    my $out = `$cmd`;
+
+    # catalog1.example.com should be skipped (catalog_only=true)
+    my $cat1file = find_zone_file($gendir, 'catalog1.example.com');
+    ok(!$cat1file, 'catalog_only zone file not generated for catalog1');
+
+    my $cat2file = find_zone_file($gendir, 'catalog2.example.com');
+    ok(!$cat2file, 'catalog_only zone file not generated for catalog2');
+
+    # named.conf should not contain catalog_only zones
+    my $namedconf = find_named_conf($gendir);
+    if ($namedconf) {
+        open(my $fh, '<', $namedconf) or do { fail("cannot read $namedconf"); return; };
+        my $conf = do { local $/; <$fh> };
+        close($fh);
+        unlike($conf, qr/catalog1\.example\.com/,
+               'catalog_only zone not in named.conf');
+        unlike($conf, qr/catalog2\.example\.com/,
+               'catalog_only zone not in named.conf');
+    }
+};
+
+
+# =========================================================================
+# Test 14: Sync mode - remove stale members
+# =========================================================================
+subtest 'sync mode removes stale members' => sub {
+    plan skip_all => 'catalog1 not created' unless ($cat1_id && $cat1_id > 0);
+
+    # Create a temporary catalog zone file with only 2 members (alpha removed)
+    my $tmpdir = tempdir(CLEANUP => 1);
+    my $syncfile = "$tmpdir/catalog1-sync.zone";
+    open(my $fh, '>', $syncfile) or do { fail("cannot write $syncfile"); return; };
+    print $fh <<'ZONE';
+$TTL 0
+$ORIGIN catalog1.example.com.
+@	IN	SOA	ns1.example.com. admin.example.com. (
+		2024020101 3600 900 604800 0 )
+	IN	NS	invalid.
+version.catalog		IN	TXT	"2"
+uuid-002.zones.catalog	IN	PTR	beta.example.com.
+uuid-003.zones.catalog	IN	PTR	shared.example.com.
+group.uuid-002.zones.catalog	IN	TXT	"backend"
+group.uuid-003.zones.catalog	IN	TXT	"shared-group"
+ZONE
+    close($fh);
+
+    my $cmd = "$install_dir/import-catalog-zone --verbose --sync " .
+              "--file=$syncfile $server catalog1.example.com 2>&1";
+    my $out = `$cmd`;
+    my $rc = $? >> 8;
+    is($rc, 0, 'import-catalog-zone --sync exits 0') or diag($out);
+    like($out, qr/[Rr]emov.*alpha/i, 'alpha.example.com removed during sync');
+
+    # Verify alpha is no longer in catalog1
+    my $rec = {};
+    get_zone_catalog_members($cat1_id, $rec);
+    my %members;
+    for my $m (@{$rec->{members}}) {
+        $members{lc($m->[1])} = 1;
+    }
+    ok(!exists $members{'alpha.example.com'},
+       'alpha.example.com removed from catalog1');
+    ok(exists $members{'beta.example.com'},
+       'beta.example.com still in catalog1');
+    ok(exists $members{'shared.example.com'},
+       'shared.example.com still in catalog1');
+    is($rec->{count}, 2, 'catalog1 now has 2 members after sync');
+};
+
+
+# =========================================================================
+# Test 15: Dry-run mode makes no changes
+# =========================================================================
+subtest 'dry-run mode makes no changes' => sub {
+    plan skip_all => 'catalog1 not created' unless ($cat1_id && $cat1_id > 0);
+
+    # Get current member count
+    my $before = {};
+    get_zone_catalog_members($cat1_id, $before);
+    my $count_before = $before->{count};
+
+    # Create zone file with extra member
+    my $tmpdir = tempdir(CLEANUP => 1);
+    my $dryfile = "$tmpdir/catalog1-dry.zone";
+    open(my $fh, '>', $dryfile) or do { fail("cannot write $dryfile"); return; };
+    print $fh <<'ZONE';
+$TTL 0
+$ORIGIN catalog1.example.com.
+@	IN	SOA	ns1.example.com. admin.example.com. (
+		2024030101 3600 900 604800 0 )
+	IN	NS	invalid.
+version.catalog		IN	TXT	"2"
+uuid-002.zones.catalog	IN	PTR	beta.example.com.
+uuid-003.zones.catalog	IN	PTR	shared.example.com.
+uuid-004.zones.catalog	IN	PTR	newzone.example.com.
+ZONE
+    close($fh);
+
+    my $cmd = "$install_dir/import-catalog-zone --dryrun --verbose " .
+              "--file=$dryfile $server catalog1.example.com 2>&1";
+    my $out = `$cmd`;
+    my $rc = $? >> 8;
+    is($rc, 0, 'import-catalog-zone --dryrun exits 0') or diag($out);
+    like($out, qr/dry-run/i, 'output mentions dry-run');
+
+    # Member count should not change
+    my $after = {};
+    get_zone_catalog_members($cat1_id, $after);
+    is($after->{count}, $count_before,
+       'member count unchanged after dry-run');
+};
+
+
+# =========================================================================
+# Test 16: BackEnd API - remove and update compositions
+# =========================================================================
+subtest 'remove and update compositions' => sub {
+    plan skip_all => 'aggregate zone not created' unless ($agg_id && $agg_id > 0);
+
+    # Remove catalog2 from aggregate
+    my $res = remove_catalog_composition($agg_id, $cat2_id);
+    ok($res >= 0, 'removed catalog2 from aggregate');
+
+    my $comp_rec = {};
+    get_catalog_compositions($agg_id, $comp_rec);
+    is($comp_rec->{count}, 1, 'aggregate has 1 source after removal');
+
+    # Re-add with different priority
+    $res = add_catalog_composition($agg_id, $cat2_id, 5);
+    ok($res >= 0, 'added catalog2 back with priority=5');
+
+    $comp_rec = {};
+    get_catalog_compositions($agg_id, $comp_rec);
+    is($comp_rec->{count}, 2, 'aggregate has 2 sources again');
+
+    # Now catalog2 (priority=5) should be first
+    # Columns: [id, source_zone_id, source_name, priority]
+    my @comps = @{$comp_rec->{compositions}};
+    is($comps[0][1], $cat2_id, 'catalog2 is now first (priority=5)');
+    is($comps[1][1], $cat1_id, 'catalog1 is now second (priority=10)');
+
+    # update_catalog_compositions - change priorities
+    $res = update_catalog_compositions($agg_id,
+                                       [$cat1_id, $cat2_id],
+                                       {$cat1_id => 1, $cat2_id => 99});
+    ok($res >= 0, 'update_catalog_compositions succeeds');
+
+    $comp_rec = {};
+    get_catalog_compositions($agg_id, $comp_rec);
+    @comps = @{$comp_rec->{compositions}};
+    is($comps[0][1], $cat1_id, 'catalog1 now first after priority update (1)');
+    is($comps[0][3], 1, 'catalog1 priority updated to 1');
+    is($comps[1][1], $cat2_id, 'catalog2 now second (priority 99)');
+    is($comps[1][3], 99, 'catalog2 priority updated to 99');
+};
+
+
+# =========================================================================
+# Test 17: Generate after priority swap - verify different conflict winner
+# =========================================================================
+subtest 'generate after priority swap - conflict winner changes' => sub {
+    plan skip_all => 'aggregate zone not created' unless ($agg_id && $agg_id > 0);
+
+    my $gendir = tempdir(CLEANUP => 1);
+    my $cmd = "$install_dir/sauron --verbose --bind $server $gendir 2>&1";
+    my $out = `$cmd`;
+    my $rc = $? >> 8;
+    is($rc, 0, 'sauron --bind exits 0') or do { diag($out); return; };
+
+    my $aggfile = find_zone_file($gendir, 'aggregate.example.com');
+    ok($aggfile && -r $aggfile, 'aggregate zone file generated') or return;
+
+    open(my $fh, '<', $aggfile) or do { fail("cannot read $aggfile"); return; };
+    my $content = do { local $/; <$fh> };
+    close($fh);
+
+    # shared.example.com should still appear only once
+    my @shared_ptrs = ($content =~ /PTR\s+shared\.example\.com\./g);
+    is(scalar @shared_ptrs, 1,
+       'shared.example.com still appears exactly once');
+
+    # With catalog1 at priority=1 (wins), shared's group should be from catalog1
+    my $shared_zid = get_zone_id('shared.example.com', $serverid);
+    if ($shared_zid > 0) {
+        like($content, qr/group\.uuid-$shared_zid\.zones\.catalog\s+.*\tTXT\s+"shared-group"/,
+             'shared group from catalog1 (now priority=1) wins');
+    }
+};
+
+
+# =========================================================================
+# Cleanup: remove test zones (in correct dependency order)
+# =========================================================================
+subtest 'cleanup: remove test zones' => sub {
+    # Remove aggregate zone first (has FK references to catalog compositions)
+    if ($agg_id && $agg_id > 0) {
+        my $res = delete_zone($agg_id);
+        ok($res >= 0, "deleted aggregate zone (id=$agg_id)") or diag("error=$res");
+    }
+
+    # Remove member zones (must remove from catalogs first via cascade)
+    for my $zname ('alpha.example.com', 'beta.example.com',
+                   'gamma.example.com', 'delta.example.com',
+                   'shared.example.com') {
+        my $zid = get_zone_id($zname, $serverid);
+        if ($zid > 0) {
+            my $res = delete_zone($zid);
+            ok($res >= 0, "deleted $zname") or diag("error=$res");
+        }
+    }
+
+    # Remove catalog zones
+    for my $catname ('catalog1.example.com', 'catalog2.example.com') {
+        my $zid = get_zone_id($catname, $serverid);
+        if ($zid > 0) {
+            my $res = delete_zone($zid);
+            ok($res >= 0, "deleted $catname") or diag("error=$res");
+        }
+    }
+
+    # Cleanup test server
+    if ($serverid > 0) {
+        db_exec("DELETE FROM servers WHERE id=$serverid");
+        pass("cleaned up test server");
+    }
+};
+
+done_testing();
+
+
+# =========================================================================
+# Helper functions
+# =========================================================================
+
+sub find_zone_file {
+    my ($gendir, $zonename) = @_;
+    # Sauron generates zone files in subdirectories or flat
+    my @candidates;
+    require File::Find;
+    File::Find::find(sub {
+        push @candidates, $File::Find::name
+            if (-f $_ && $File::Find::name =~ /\Q$zonename\E/);
+    }, $gendir);
+    return $candidates[0] if @candidates;
+    return undef;
+}
+
+sub find_named_conf {
+    my ($gendir) = @_;
+    my @candidates;
+    require File::Find;
+    File::Find::find(sub {
+        push @candidates, $File::Find::name
+            if (-f $_ && /named.*\.conf$/);
+    }, $gendir);
+    return $candidates[0] if @candidates;
+    return undef;
+}

--- a/t/13-catalog-aggregate.t
+++ b/t/13-catalog-aggregate.t
@@ -602,6 +602,92 @@ subtest 'generate after priority swap - conflict winner changes' => sub {
 
 
 # =========================================================================
+# Test 18: --group auto-creates non-existent Sauron group
+# =========================================================================
+subtest '--group auto-creates non-existent group' => sub {
+    plan skip_all => 'catalog1 not created' unless ($cat1_id && $cat1_id > 0);
+
+    my $test_group = 'catalog-import-test-grp';
+
+    # Ensure group does not exist yet
+    my $pre_gid = get_group_by_name($serverid, $test_group);
+    if ($pre_gid > 0) {
+        db_exec("DELETE FROM groups WHERE id=$pre_gid");
+    }
+
+    # Re-import catalog1 with --group (group should be auto-created)
+    my $zonefile = "$testdata/catalog1.example.com.zone";
+    my $cmd = "$install_dir/import-catalog-zone --verbose --catalog-only " .
+              "--group=$test_group " .
+              "$server catalog1.example.com $zonefile 2>&1";
+    my $out = `$cmd`;
+    my $rc = $? >> 8;
+    is($rc, 0, 'import-catalog-zone --group exits 0') or diag($out);
+    like($out, qr/[Cc]reat.*group.*$test_group/,
+         'output mentions group creation');
+
+    # Verify group now exists
+    my $gid = get_group_by_name($serverid, $test_group);
+    ok($gid > 0, "group '$test_group' auto-created (id=$gid)");
+
+    # Cleanup: remove the test group
+    if ($gid > 0) {
+        db_exec("DELETE FROM groups WHERE id=$gid");
+    }
+};
+
+
+# =========================================================================
+# Test 19: --ignore-groups skips RFC 9432 group TXT records
+# =========================================================================
+subtest '--ignore-groups skips group assignments' => sub {
+    plan skip_all => 'catalog1 not created' unless ($cat1_id && $cat1_id > 0);
+
+    # Clear existing group assignments from catalog1 members
+    my $rec_before = {};
+    get_zone_catalog_members($cat1_id, $rec_before);
+    for my $m (@{$rec_before->{members}}) {
+        set_member_groups($m->[0], $cat1_id, []);
+    }
+
+    # Create a zone file with group assignments
+    my $tmpdir = tempdir(CLEANUP => 1);
+    my $igfile = "$tmpdir/catalog1-ig.zone";
+    open(my $fh, '>', $igfile) or do { fail("cannot write $igfile"); return; };
+    print $fh <<'ZONE';
+$TTL 0
+$ORIGIN catalog1.example.com.
+@	IN	SOA	ns1.example.com. admin.example.com. (
+		2024040101 3600 900 604800 0 )
+	IN	NS	invalid.
+version.catalog		IN	TXT	"2"
+uuid-002.zones.catalog	IN	PTR	beta.example.com.
+uuid-003.zones.catalog	IN	PTR	shared.example.com.
+group.uuid-002.zones.catalog	IN	TXT	"should-be-ignored"
+group.uuid-003.zones.catalog	IN	TXT	"should-be-ignored"
+ZONE
+    close($fh);
+
+    my $cmd = "$install_dir/import-catalog-zone --verbose --ignore-groups " .
+              "$server catalog1.example.com $igfile 2>&1";
+    my $out = `$cmd`;
+    my $rc = $? >> 8;
+    is($rc, 0, 'import-catalog-zone --ignore-groups exits 0') or diag($out);
+
+    # Verify no group assignments were set
+    my $rec_after = {};
+    get_zone_catalog_members($cat1_id, $rec_after);
+
+    my $has_groups = 0;
+    for my $m (@{$rec_after->{members}}) {
+        my $grps = $m->[7];
+        $has_groups++ if (ref($grps) eq 'ARRAY' && @{$grps} > 0);
+    }
+    is($has_groups, 0, 'no group assignments set with --ignore-groups');
+};
+
+
+# =========================================================================
 # Cleanup: remove test zones (in correct dependency order)
 # =========================================================================
 subtest 'cleanup: remove test zones' => sub {

--- a/t/13-catalog-aggregate.t
+++ b/t/13-catalog-aggregate.t
@@ -602,38 +602,53 @@ subtest 'generate after priority swap - conflict winner changes' => sub {
 
 
 # =========================================================================
-# Test 18: --group auto-creates non-existent Sauron group
+# Test 18: --group auto-creates catalog group definition (zone-scoped)
 # =========================================================================
-subtest '--group auto-creates non-existent group' => sub {
+subtest '--group auto-creates catalog group definition' => sub {
     plan skip_all => 'catalog1 not created' unless ($cat1_id && $cat1_id > 0);
 
     my $test_group = 'catalog-import-test-grp';
 
-    # Ensure group does not exist yet
-    my $pre_gid = get_group_by_name($serverid, $test_group);
-    if ($pre_gid > 0) {
-        db_exec("DELETE FROM groups WHERE id=$pre_gid");
-    }
+    # Ensure group definition does not exist yet in catalog zone
+    db_exec("DELETE FROM catalog_group_defs " .
+            "WHERE catalog_zone_id=$cat1_id AND group_name=" .
+            db_encode_str($test_group));
 
-    # Re-import catalog1 with --group (group should be auto-created)
+    # Re-import catalog1 with trailing --group/--sync (group def should be auto-created)
     my $zonefile = "$testdata/catalog1.example.com.zone";
     my $cmd = "$install_dir/import-catalog-zone --verbose --catalog-only " .
-              "--group=$test_group " .
-              "$server catalog1.example.com $zonefile 2>&1";
+              "$server catalog1.example.com $zonefile " .
+	      "--group=$test_group --sync 2>&1";
     my $out = `$cmd`;
     my $rc = $? >> 8;
     is($rc, 0, 'import-catalog-zone --group exits 0') or diag($out);
     like($out, qr/[Cc]reat.*group.*$test_group/,
          'output mentions group creation');
 
-    # Verify group now exists
-    my $gid = get_group_by_name($serverid, $test_group);
-    ok($gid > 0, "group '$test_group' auto-created (id=$gid)");
+    # Verify group definition now exists in catalog zone (zone-scoped)
+    my $grp_rec = {};
+    get_catalog_group_defs($cat1_id, $grp_rec);
+    my %gnames = map { $_->[1] => 1 } @{$grp_rec->{groups}};
+    ok($gnames{$test_group},
+       "group def '$test_group' auto-created in catalog zone");
 
-    # Cleanup: remove the test group
-    if ($gid > 0) {
-        db_exec("DELETE FROM groups WHERE id=$gid");
+    # Verify group assigned to members
+    my $mem_rec = {};
+    get_zone_catalog_members($cat1_id, $mem_rec);
+    my $has_test_group = 0;
+    for my $m (@{$mem_rec->{members}}) {
+        my $grps = $m->[7];
+        $has_test_group++ if (ref($grps) eq 'ARRAY' && grep { $_ eq $test_group } @{$grps});
     }
+    ok($has_test_group > 0,
+       "group '$test_group' assigned to at least one member");
+
+    # Cleanup: remove the test group definition
+    db_exec("DELETE FROM zone_catalog_groups " .
+            "WHERE group_name=" . db_encode_str($test_group));
+    db_exec("DELETE FROM catalog_group_defs " .
+            "WHERE catalog_zone_id=$cat1_id AND group_name=" .
+            db_encode_str($test_group));
 };
 
 

--- a/t/13-catalog-aggregate.t
+++ b/t/13-catalog-aggregate.t
@@ -90,7 +90,7 @@ subtest 'import catalog zone #1' => sub {
     plan skip_all => "Zone file not found: $zonefile" unless (-r $zonefile);
 
     my $cmd = "$install_dir/import-catalog-zone --verbose --catalog-only " .
-              "--file=$zonefile $server catalog1.example.com 2>&1";
+	      "$server catalog1.example.com $zonefile 2>&1";
     my $out = `$cmd`;
     my $rc = $? >> 8;
     is($rc, 0, 'import-catalog-zone exits 0') or diag($out);
@@ -188,7 +188,7 @@ subtest 'import catalog zone #2' => sub {
     plan skip_all => "Zone file not found: $zonefile" unless (-r $zonefile);
 
     my $cmd = "$install_dir/import-catalog-zone --verbose --catalog-only " .
-              "--file=$zonefile $server catalog2.example.com 2>&1";
+	      "$server catalog2.example.com $zonefile 2>&1";
     my $out = `$cmd`;
     my $rc = $? >> 8;
     is($rc, 0, 'import-catalog-zone exits 0') or diag($out);
@@ -458,7 +458,7 @@ ZONE
     close($fh);
 
     my $cmd = "$install_dir/import-catalog-zone --verbose --sync " .
-              "--file=$syncfile $server catalog1.example.com 2>&1";
+	      "$server catalog1.example.com $syncfile 2>&1";
     my $out = `$cmd`;
     my $rc = $? >> 8;
     is($rc, 0, 'import-catalog-zone --sync exits 0') or diag($out);
@@ -510,7 +510,7 @@ ZONE
     close($fh);
 
     my $cmd = "$install_dir/import-catalog-zone --dryrun --verbose " .
-              "--file=$dryfile $server catalog1.example.com 2>&1";
+	      "$server catalog1.example.com $dryfile 2>&1";
     my $out = `$cmd`;
     my $rc = $? >> 8;
     is($rc, 0, 'import-catalog-zone --dryrun exits 0') or diag($out);

--- a/test/catalog1.example.com.zone
+++ b/test/catalog1.example.com.zone
@@ -1,0 +1,32 @@
+; test/catalog1.example.com.zone
+; Test catalog zone with RFC 9432 format - source catalog #1
+; Contains member zones with group assignments
+;
+$TTL 0
+$ORIGIN catalog1.example.com.
+@	IN	SOA	ns1.example.com. admin.example.com. (
+		2024010101	; serial
+		3600		; refresh
+		900		; retry
+		604800		; expire
+		0		; minimum
+		)
+	IN	NS	invalid.
+;
+; Catalog zone version (RFC 9432 §4.2)
+;
+version.catalog		IN	TXT	"2"
+;
+; Member zones (PTR records under *.zones.catalog)
+;
+uuid-001.zones.catalog	IN	PTR	alpha.example.com.
+uuid-002.zones.catalog	IN	PTR	beta.example.com.
+uuid-003.zones.catalog	IN	PTR	shared.example.com.
+;
+; Group assignments (TXT records under group.*.zones.catalog)
+;
+group.uuid-001.zones.catalog	IN	TXT	"frontend"
+group.uuid-002.zones.catalog	IN	TXT	"backend"
+group.uuid-003.zones.catalog	IN	TXT	"shared-group"
+;
+; eof

--- a/test/catalog2.example.com.zone
+++ b/test/catalog2.example.com.zone
@@ -1,0 +1,32 @@
+; test/catalog2.example.com.zone
+; Test catalog zone with RFC 9432 format - source catalog #2
+; Contains overlapping member (shared.example.com) for conflict testing
+;
+$TTL 0
+$ORIGIN catalog2.example.com.
+@	IN	SOA	ns1.example.com. admin.example.com. (
+		2024010101	; serial
+		3600		; refresh
+		900		; retry
+		604800		; expire
+		0		; minimum
+		)
+	IN	NS	invalid.
+;
+; Catalog zone version (RFC 9432 §4.2)
+;
+version.catalog		IN	TXT	"2"
+;
+; Member zones (PTR records under *.zones.catalog)
+;
+uuid-101.zones.catalog	IN	PTR	gamma.example.com.
+uuid-102.zones.catalog	IN	PTR	delta.example.com.
+uuid-103.zones.catalog	IN	PTR	shared.example.com.
+;
+; Group assignments (TXT records under group.*.zones.catalog)
+;
+group.uuid-101.zones.catalog	IN	TXT	"monitoring"
+group.uuid-102.zones.catalog	IN	TXT	"monitoring"
+group.uuid-103.zones.catalog	IN	TXT	"overlap-group"
+;
+; eof


### PR DESCRIPTION
# Add Aggregate Catalog Zones and `import-catalog-zone` Script

## Summary

This PR introduces **aggregate catalog zones** (type `A`) and the `import-catalog-zone` CLI script for importing external DNS catalog zones (RFC 9432) into Sauron. Together, these features allow merging members from multiple source catalog zones into a single output catalog zone with priority-based conflict resolution.

## Motivation

Organizations managing DNS across multiple teams or external providers often have several independent catalog zones. This feature enables:

- **Importing** external catalog zones (via AXFR or zone file) as read-only shadow catalogs in Sauron
- **Aggregating** multiple catalog zones into one unified catalog zone for BIND consumption
- **Priority-based conflict resolution** when the same member zone appears in more than one source catalog

## Changes

### New: `import-catalog-zone` Script
- Positional CLI syntax aligned with other import scripts:
  `import-catalog-zone [options] <servername> <catalog-zone> [<zone file>]`
- Imports an external catalog zone from a zone file (positional arg) or via AXFR (`--nameserver`)
- `--nameserver=<host>[:port][/zone]` supports custom port and AXFR zone override
- Additional `--axfr-zone` and `--axfr-port` options for fine-grained AXFR control
- Parses RFC 9432 PTR records (member zones) and TXT records (group assignments)
- Creates a shadow catalog zone (type `C`, `catalog_only=true`) in Sauron
- `--sync` mode: incremental updates — adds new members, removes stale ones
- `--dryrun` mode: safe preview without any database changes
- `--group=<name>`: assigns imported member zones to a catalog group; auto-creates the group definition in the catalog zone if it does not exist
- `--ignore-groups`: skips RFC 9432 group TXT records from the imported catalog zone
- Automatically creates group definitions from imported catalog data
- Added to `PROGS` in `Makefile.in` for installation

### New: Aggregate Catalog Zone (Type `A`)
- New zone type `A` that merges members from multiple source catalog zones (type `C`)
- Source catalogs are linked via the new `catalog_compositions` table with configurable priority
- Lower priority number = higher precedence during conflict resolution
- Zone file generator produces a merged catalog zone output with:
  - `version.catalog TXT "2"` record
  - PTR and group TXT records from all source catalogs
  - Source provenance comments
  - Conflict reports on stdout when duplicate members are suppressed

### New: `catalog_only` Flag on Zones
- Boolean column `catalog_only` on the `zones` table
- When `true`, the zone is completely skipped during generation (no `named.conf` entry, no zone file)
- Intended for shadow catalog zones that exist solely as data sources for aggregation

### Schema Changes
- **New table:** `catalog_compositions` — maps aggregate zone → source catalog zone with priority
  - Foreign keys with `ON DELETE CASCADE` to `zones`
  - Unique constraint on `(composite_zone_id, source_zone_id)`
  - Check constraints: `priority > 0`, no self-reference
  - Indexes for fast lookups by composite zone ID and priority
- **New column:** `zones.catalog_only` (`BOOL DEFAULT false`)
- **Updated:** `zones.type` comment documents new `C` (Catalog) and `A` (Aggregate catalog) types
- **Migration script:** `sql/dbconvert_1.7to1.8` updated with `ALTER TABLE` and `CREATE TABLE` statements

### Backend (`Sauron/BackEnd.pm`)
- Extended `get_zone()` to load `catalog_only` field and aggregate compositions
- Extended `update_zone()` and `add_zone()` to handle type `A` zones
- New exported functions:
  - `get_catalog_compositions($zone_id, $rec)` — list source catalogs for an aggregate zone
  - `add_catalog_composition($composite_id, $source_id, $priority)` — add a source with validation
  - `remove_catalog_composition($composite_id, $source_id)` — remove a source
  - `update_catalog_compositions($composite_id, $sources, $priorities)` — diff-based bulk update

### CGI Interface (`Sauron/CGI/Zones.pm`, `Sauron/CGIutil.pm`)
- `A` (Aggregate Catalog) added to zone type enums in new-zone and edit-zone forms
- New color code (`#d0b0ff`) for aggregate zones in zone list
- `catalog_only` toggle shown for catalog zones (type `C`)
- New `ftype 16` form widget: composition editor with checkboxes for source catalog selection and priority text fields
- Cleanup of aggregate-specific fields in `update_zone_wrapper()`

### Zone Generator (`sauron`)
- Aggregate zones (`type A`) treated as master zones for file generation
- `catalog_only` zones skipped entirely (no zone file, no `named.conf` entry)
- Aggregate zone output: iterates source catalogs by priority, emits merged PTR/TXT records, deduplicates by zone name, reports conflicts

### Tests
- **New:** `t/13-catalog-aggregate.t` — 671-line integration test covering:
  - Import of two catalog zone files with overlapping members
  - Shadow zone creation with `catalog_only` flag verification
  - RFC 9432 group assignment propagation
  - Aggregate zone creation and composition management
  - Priority-based conflict resolution in generated output
  - `--sync` mode (stale member removal)
  - `--dryrun` mode (no-op verification)
  - Composition CRUD operations and type validation
  - Full cleanup of test data
- **New test data:** `test/catalog1.example.com.zone`, `test/catalog2.example.com.zone`
- **CI:** Added `t/13-catalog-aggregate.t` to `.github/workflows/ci.yml` DB-enabled test stage

## Files Changed

| File | Change |
|------|--------|
| `import-catalog-zone` | New script (641 lines) |
| `Sauron/BackEnd.pm` | +223 lines — aggregate composition API |
| `Sauron/CGIutil.pm` | +63 lines — ftype 16 composition editor |
| `Sauron/CGI/Zones.pm` | +25/-6 — type A support in forms and zone list |
| `sauron` | +81/-6 — aggregate zone generation, catalog_only skip |
| `sql/catalog_compositions.sql` | New table (42 lines) |
| `sql/zones.sql` | +7/-1 — catalog_only column, type comment update |
| `sql/dbconvert_1.7to1.8` | +45 lines — migration DDL |
| `init/tables.sql` | +4/-1 — updated default schema |
| `createtables` | +1 — include new SQL file |
| `Makefile.in` | +6/-4 — add script and SQL to build |
| `t/13-catalog-aggregate.t` | New test (671 lines) |
| `test/catalog1.example.com.zone` | New test data |
| `test/catalog2.example.com.zone` | New test data |
| `.github/workflows/ci.yml` | +10 — CI step for new test |
| `ChangeLog` | +22 — release notes |

## How to Test

```bash
# Run the new integration test (requires PostgreSQL):
SAURON_TEST_DSN="dbi:Pg:dbname=sauron_test" \
SAURON_INSTALL_DIR=/opt/sauron \
  prove -lv t/13-catalog-aggregate.t

# Manual: import an external catalog zone from file
./import-catalog-zone --verbose --catalog-only \
  myserver catalog1.example.com test/catalog1.example.com.zone

# Manual: dry-run import via AXFR (with custom port)
./import-catalog-zone --dryrun \
  --nameserver=ns1.example.com:5353 \
  myserver catalog.example.com

# Manual: AXFR where catalog zone name differs from fetched zone
./import-catalog-zone --nameserver=ns1.example.com/source.catalog.net \
  myserver catalog.example.com
```

## Related

- RFC 9432: DNS Catalog Zones
- Previous PR: #94 
