### PR TITLE
add KEA DHCP configuration import support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,15 @@ jobs:
             libnet-dns-perl libnet-ip-perl libnetaddr-ip-perl \
             libnet-netmask-perl libtext-table-perl \
             libcryptx-perl libjson-perl libjson-maybexs-perl \
+            libtest-simple-perl \
             libpath-tiny-perl libpg-perl libparse-recdescent-perl \
             libdate-manip-perl libencode-locale-perl
+        shell: bash
+
+      - name: Verify core Perl test modules
+        run: |
+          set -e
+          perl -MTest::More -MJSON::PP -e 'print "Perl test modules OK\n"'
         shell: bash
 
       - name: Create DB.pm symlink
@@ -106,8 +113,15 @@ jobs:
             libnet-dns-perl libnet-ip-perl libnetaddr-ip-perl \
             libnet-netmask-perl libtext-table-perl \
             libcryptx-perl libjson-perl libjson-maybexs-perl \
+            libtest-simple-perl \
             libpath-tiny-perl libpg-perl libparse-recdescent-perl \
             libdate-manip-perl libencode-locale-perl
+        shell: bash
+
+      - name: Verify core Perl test modules
+        run: |
+          set -e
+          perl -MTest::More -MJSON::PP -e 'print "Perl test modules OK\n"'
         shell: bash
 
       - name: Wait for PostgreSQL

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,8 @@
 0.9.0 (beta)
+	- Added KEA DHCP configuration import support: parses KEA JSON 
+	  configs (DHCPv4/DHCPv6) and converts subnets, pools, reservations, 
+	  shared-networks and options to ISC-like internal format used 
+	  by import-dhcp [svamberg]
 	- Approvals (new feature) [svamberg]
 	  - Mandatory justification requirement for approval requests
 	    - Two-step submission workflow: users must provide justification

--- a/README
+++ b/README
@@ -100,9 +100,9 @@ INSTALLATION
 	Copy images under icons/ directory to sauron/icons/ directory
 	under your web server root directory (or just make a symbolic link)
 
-  9) now you can use the web interface to create a server and zones, or
-     you can import existing named/dhcpd configurations using
-     import/iport-dhcp utilities. Or you can try out the demo database
+    9) now you can use the web interface to create a server and zones, or
+      you can import existing named/dhcpd/KEA configurations using
+      import/import-dhcp utilities. Or you can try out the demo database
      that can be found under test/ directory in source tree.
 
 
@@ -149,7 +149,8 @@ COMMANDS
    new server and related zones into Sauron.
 
  import-dhcp
-   Utility for updating existing server using dhcpd configuration; 
+   Utility for updating existing server using ISC dhcpd or KEA JSON
+  DHCP configuration;
    adds Ethernet addressess for hosts and to builds network map for
    the server.
 

--- a/Sauron/UtilDhcp.pm
+++ b/Sauron/UtilDhcp.pm
@@ -7,6 +7,7 @@
 package Sauron::UtilDhcp;
 require Exporter;
 use IO::File;
+use JSON::PP;
 use Sauron::Util;
 use strict;
 use vars qw($VERSION @ISA @EXPORT);
@@ -15,10 +16,271 @@ use open ':locale';
 $VERSION = '$Id:$ ';
 
 @ISA = qw(Exporter); # Inherit from Exporter
-@EXPORT = qw(process_dhcpdconf);
+@EXPORT = qw(process_dhcpdconf process_kea_dhcpconf is_kea_dhcpconf);
 
 
 my $debug = 0;
+
+sub _init_data_refs($) {
+  my ($data) = @_;
+
+  $$data{GLOBAL} = [] unless (defined $$data{GLOBAL} && ref($$data{GLOBAL}) eq 'ARRAY');
+  foreach my $key ('shared-network','subnet','subnet6','group','class','subclass','pool','pool6','host') {
+    $$data{$key} = {} unless (defined $$data{$key} && ref($$data{$key}) eq 'HASH');
+  }
+
+  return 0;
+}
+
+sub _arrayref($) {
+  my ($value) = @_;
+  return $value if (defined $value && ref($value) eq 'ARRAY');
+  return [];
+}
+
+sub _normalize_hex_sequence($) {
+  my ($value) = @_;
+
+  return '' unless (defined $value);
+
+  if ($value =~ /^[0-9A-Fa-f]+$/ && (length($value) % 2) == 0) {
+    my @tmp = ($value =~ /(..)/g);
+    return join(':',@tmp);
+  }
+
+  return $value;
+}
+
+sub _bits_to_netmask($) {
+  my ($bits) = @_;
+  my @octets;
+  my ($full,$rest);
+
+  return '' if (!defined $bits || $bits < 0 || $bits > 32);
+
+  $full = int($bits / 8);
+  $rest = $bits % 8;
+
+  for my $i (0..3) {
+    my $octet = 0;
+
+    if ($i < $full) {
+      $octet = 255;
+    }
+    elsif ($i == $full && $rest > 0) {
+      $octet = (0xFF << (8 - $rest)) & 0xFF;
+    }
+
+    push @octets, $octet;
+  }
+
+  return join('.',@octets);
+}
+
+sub _kea_ipv4_subnet_key($) {
+  my ($subnet) = @_;
+  my ($ip,$bits,$mask);
+
+  return undef unless (defined $subnet);
+  return undef unless ($subnet =~ /^\s*(\d{1,3}(?:\.\d{1,3}){3})\/(\d{1,2})\s*$/);
+
+  ($ip,$bits) = ($1,$2);
+  return undef if ($bits < 0 || $bits > 32);
+
+  $mask = _bits_to_netmask($bits);
+  return undef unless ($mask);
+
+  return "$ip netmask $mask";
+}
+
+sub _kea_option_to_line($) {
+  my ($opt) = @_;
+  my ($name,$space,$line);
+
+  return undef unless (defined $opt && ref($opt) eq 'HASH');
+
+  $name = $$opt{name};
+  return undef unless (defined $name && $name ne '');
+
+  $space = $$opt{space};
+  if (defined $space && $space ne '' && $space !~ /^dhcp[46]?$/i) {
+    $name = "$space.$name";
+  }
+
+  $line = "option $name";
+  if (defined $$opt{data} && $$opt{data} ne '') {
+    $line .= " $$opt{data}";
+  }
+
+  $line .= ';';
+  return $line;
+}
+
+sub _append_option_data_lines($$) {
+  my ($dst,$optdata) = @_;
+
+  return unless (defined $dst && ref($dst) eq 'ARRAY');
+
+  foreach my $opt (@{_arrayref($optdata)}) {
+    my $line = _kea_option_to_line($opt);
+    push @$dst, $line if (defined $line);
+  }
+}
+
+sub _kea_pool_bounds($) {
+  my ($pool) = @_;
+  my ($start,$end,$range);
+
+  return () unless (defined $pool && ref($pool) eq 'HASH');
+
+  if (defined $$pool{start} && defined $$pool{end}) {
+    return ($$pool{start},$$pool{end});
+  }
+
+  if (defined $$pool{'start-address'} && defined $$pool{'end-address'}) {
+    return ($$pool{'start-address'},$$pool{'end-address'});
+  }
+
+  $range = $$pool{pool};
+  return () unless (defined $range);
+  return ($1,$2) if ($range =~ /^\s*(\S+)\s*\-\s*(\S+)\s*$/);
+
+  return ();
+}
+
+sub _append_kea_host($$$$$) {
+  my ($data,$reservation,$v6,$hostcounter,$seenhosts) = @_;
+  my ($name,$ip,$id_line,@host_data);
+
+  return unless (defined $reservation && ref($reservation) eq 'HASH');
+
+  $name = $$reservation{hostname};
+  unless (defined $name && $name ne '') {
+    $$hostcounter++;
+    $name = "host-$$hostcounter";
+  }
+
+  if ($$seenhosts{$name}) {
+    $$hostcounter++;
+    $name .= "-$$hostcounter";
+  }
+  $$seenhosts{$name}=1;
+
+  if (!$v6) {
+    $ip = $$reservation{'ip-address'};
+    $id_line = $$reservation{'hw-address'};
+    return unless (defined $ip && $ip ne '' && defined $id_line && $id_line ne '');
+
+    push @host_data, "fixed-address $ip;";
+    push @host_data, "hardware ethernet $id_line;";
+  }
+  else {
+    $ip = $$reservation{'ip-address'};
+    if ((!defined $ip || $ip eq '') && ref($$reservation{'ip-addresses'}) eq 'ARRAY') {
+      $ip = $$reservation{'ip-addresses'}->[0];
+    }
+
+    $id_line = $$reservation{duid};
+    return unless (defined $ip && $ip ne '' && defined $id_line && $id_line ne '');
+
+    $id_line = _normalize_hex_sequence($id_line);
+    push @host_data, "fixed-address6 $ip;";
+    push @host_data, "host-identifier option dhcp6.client-id $id_line;";
+  }
+
+  _append_option_data_lines(\@host_data,$$reservation{'option-data'});
+  $$data{host}->{$name} = \@host_data;
+}
+
+sub _append_kea_subnet($$$$$$$) {
+  my ($data,$subnet,$v6,$shared_name,$poolcounter,$hostcounter,$seenhosts) = @_;
+  my ($subnet_key,$pool_key,$key,@subnet_data,$vlan_name);
+
+  return unless (defined $subnet && ref($subnet) eq 'HASH');
+  return unless (defined $$subnet{subnet} && $$subnet{subnet} ne '');
+
+  $subnet_key = (!$v6 ? 'subnet' : 'subnet6');
+  $pool_key = (!$v6 ? 'pool' : 'pool6');
+
+  if (!$v6) {
+    $key = _kea_ipv4_subnet_key($$subnet{subnet});
+    return unless ($key);
+  }
+  else {
+    $key = $$subnet{subnet};
+  }
+
+  if (defined $shared_name && $shared_name ne '') {
+    $vlan_name = ($shared_name =~ /\s/ ? "\"$shared_name\"" : $shared_name);
+    push @subnet_data, "VLAN $vlan_name";
+  }
+
+  _append_option_data_lines(\@subnet_data,$$subnet{'option-data'});
+  $$data{$subnet_key}->{$key} = \@subnet_data;
+
+  foreach my $pool (@{_arrayref($$subnet{pools})}) {
+    my ($start,$end) = _kea_pool_bounds($pool);
+    my @pool_data;
+    my $pool_name;
+
+    next unless ($start && $end);
+
+    $$poolcounter++;
+    $pool_name = (!$v6 ? "pool-$$poolcounter" : "pool6-$$poolcounter");
+
+    push @pool_data, (!$v6 ? "range $start $end;" : "range6 $start $end;");
+    _append_option_data_lines(\@pool_data,$$pool{'option-data'});
+
+    $$data{$pool_key}->{$pool_name} = \@pool_data;
+  }
+
+  foreach my $res (@{_arrayref($$subnet{reservations})}) {
+    _append_kea_host($data,$res,$v6,$hostcounter,$seenhosts);
+  }
+}
+
+sub _append_kea_class($$) {
+  my ($data,$class) = @_;
+  my ($name,$test,@class_data);
+
+  return unless (defined $class && ref($class) eq 'HASH');
+
+  $name = $$class{name};
+  return if (ref($name));
+  return unless (defined $name && $name ne '');
+
+  $test = $$class{test};
+  if (defined $test && !ref($test)) {
+    $test =~ s/(^\s+|\s+$)//g;
+    push @class_data, "match if $test;" if ($test ne '');
+  }
+  _append_option_data_lines(\@class_data,$$class{'option-data'});
+
+  $$data{class}->{$name} = \@class_data;
+}
+
+
+sub is_kea_dhcpconf($) {
+  my ($filename) = @_;
+  my $fh = IO::File->new();
+
+  return 0 unless (-r $filename);
+  open($fh,$filename) || return 0;
+
+  while (<$fh>) {
+    s/^\s+//;
+    s/\s+$//;
+
+    next if ($_ eq '');
+    next if (/^#/ || m{^//} || m{^/\*} || /^\*/);
+
+    close($fh);
+    return (/^\{/) ? 1 : 0;
+  }
+
+  close($fh);
+  return 0;
+}
 
 # parse dhcpd.conf file, build hash of all entries in the file
 #
@@ -63,6 +325,75 @@ sub process_dhcpdconf($$$) {
   process_line($tmp,$data,\%state,$v6);
 
   close($fh);
+
+  _init_data_refs($data);
+
+  return 0;
+}
+
+
+sub process_kea_dhcpconf($$$) {
+  my ($filename,$data,$v6)=@_;
+  my $fh = IO::File->new();
+  my ($json_text,$root,$scope,$cfg,$subnet_key,$poolcounter,$hostcounter,%seenhosts);
+
+  fatal("cannot read conf file: $filename") unless (-r $filename);
+  open($fh,$filename) || fatal("cannot open conf file: $filename");
+
+  $json_text = '';
+  while (<$fh>) {
+    $json_text .= $_;
+  }
+  close($fh);
+
+  eval {
+    my $json = JSON::PP->new();
+    $json->relaxed(1);
+    $root = $json->decode($json_text);
+  };
+  fatal("cannot parse KEA conf file: $filename ($@)") if ($@);
+
+  fatal("invalid KEA conf root in $filename")
+    unless (defined $root && ref($root) eq 'HASH');
+
+  $scope = (!$v6 ? 'Dhcp4' : 'Dhcp6');
+  $cfg = $root->{$scope};
+  fatal("KEA conf does not include $scope section")
+    unless (defined $cfg && ref($cfg) eq 'HASH');
+
+  _init_data_refs($data);
+
+  _append_option_data_lines($$data{GLOBAL},$$cfg{'option-data'});
+
+  $poolcounter = 0;
+  $hostcounter = 0;
+  $subnet_key = (!$v6 ? 'subnet4' : 'subnet6');
+
+  foreach my $shared (@{_arrayref($$cfg{'shared-networks'})}) {
+    my ($name,@sn_data);
+
+    next unless (defined $shared && ref($shared) eq 'HASH');
+
+    $name = $$shared{name};
+    unless (defined $name && $name ne '') {
+      $name = "shared-network-" . ((scalar keys %{$$data{'shared-network'}}) + 1);
+    }
+
+    _append_option_data_lines(\@sn_data,$$shared{'option-data'});
+    $$data{'shared-network'}->{$name} = \@sn_data;
+
+    foreach my $subnet (@{_arrayref($$shared{$subnet_key})}) {
+      _append_kea_subnet($data,$subnet,$v6,$name,\$poolcounter,\$hostcounter,\%seenhosts);
+    }
+  }
+
+  foreach my $subnet (@{_arrayref($$cfg{$subnet_key})}) {
+    _append_kea_subnet($data,$subnet,$v6,undef,\$poolcounter,\$hostcounter,\%seenhosts);
+  }
+
+  foreach my $class (@{_arrayref($$cfg{'client-classes'})}) {
+    _append_kea_class($data,$class);
+  }
 
   return 0;
 }

--- a/doc/command-ref.sgml
+++ b/doc/command-ref.sgml
@@ -377,12 +377,15 @@
   <arg>--help</>
   <arg><replaceable>OPTIONS</></>
   <arg choice=req><replaceable>servername</></>
-  <arg choice=req><replaceable>dhcpd.conf file</></>
+     <arg choice=req><replaceable>dhcp config file</></>
 </cmdsynopsis>
 <informaltable frame=all>
   <tgroup cols=2>
   <thead><row><entry>option</><entry>description</></row></thead>
   <tbody>
+     <row><entry><option>--kea</></>
+                <entry>Import KEA JSON configuration (otherwise format is auto-detected).</>
+     </row>
   <row><entry><option>--dir=<replaceable>directory</></></>
        <entry>Directory where included files are located (if not in 
               the directory specified in dhcpd.conf).</>

--- a/import-dhcp
+++ b/import-dhcp
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -I/usr/local/sauron
 #
-# import-dhcp - imports ISC DHCPD configuration
+# import-dhcp - imports ISC DHCPD or KEA DHCP configuration
 #
 # Copyright (c) Michal Kostenec <kostenec@civ.zcu.cz> 2013-2014.
 # Copyright (c) Timo Kokkonen <tjko@iki.fi>  2002,2003.
@@ -25,12 +25,14 @@ load_config();
 ##############################
 
 GetOptions("help|h","verbose|v","dir=s","notransaction","chaosnet=s",
-	   "global","dhcp6");
+	   "global","dhcp6","kea")
+  or fatal("invalid command-line options");
 
 if ($opt_help || @ARGV < 2) {
-    print "syntax: $0 [options] <servername> <dhcpd.conf file>\n";
+    print "syntax: $0 [options] <servername> <dhcp config file>\n";
     print "options:\n",
           "\t--dhcp6\t\t\timport DHCPv6 configuration\t\n",
+          "\t--kea\t\t\timport KEA JSON configuration\n",
           "\t--dir=<directory>\tdirectory where included files are located\n",
 	  "\t\t\t\t(if not in directory specified in dhcpd.conf)\n",
 	  "\t--chaosnet=<name>\ttreat this shared-network as default VLAN\n",
@@ -49,6 +51,7 @@ $dhcpdf = $ARGV[1];
 $user = (getpwuid($<))[0];
 $chaosnet = ($opt_chaosnet ? $opt_chaosnet : 'CHAOS');
 $opt_dhcp6 = ($opt_dhcp6 ? 1 : 0);
+$opt_kea = ($opt_kea ? 1 : 0);
 
 
 fatal("cannot read dhcpd.conf ($dhcpdf)") unless (-r $dhcpdf);
@@ -67,7 +70,13 @@ if ($dhcpdf =~ /(^.*\/)/) {
 
 # parse named.conf
 undef %data;
-process_dhcpdconf($dhcpdf,\%data,$opt_dhcp6);
+if ($opt_kea || is_kea_dhcpconf($dhcpdf)) {
+  print "Detected KEA DHCP configuration\n" if ($opt_verbose);
+  process_kea_dhcpconf($dhcpdf,\%data,$opt_dhcp6);
+}
+else {
+  process_dhcpdconf($dhcpdf,\%data,$opt_dhcp6);
+}
 
 unless ($opt_notransaction) {
   db_begin();

--- a/t/03-utildhcp.t
+++ b/t/03-utildhcp.t
@@ -5,6 +5,7 @@ use warnings;
 use FindBin;
 use lib "$FindBin::Bin/..";
 use Test::More;
+use File::Temp qw(tempfile);
 
 # Ensure DB.pm symlink
 my $db_link = "$FindBin::Bin/../Sauron/DB.pm";
@@ -31,12 +32,102 @@ subtest 'process_dhcpdconf v4' => sub {
     process_dhcpdconf($conf_file, \%data, 0);
 
     ok(scalar keys %data > 0, 'parsed data has entries');
+    ok(ref $data{'shared-network'} eq 'HASH', 'shared-network structure parsed');
+    ok(ref $data{subnet} eq 'HASH', 'subnet structure parsed');
+    ok(scalar keys %{$data{'shared-network'}} > 0, 'shared-network entries found');
+    ok(exists $data{subnet}{'10.10.100.0 netmask 255.255.255.0'}, 'known subnet key parsed');
+};
 
-    # The test dhcpd.conf has shared-networks and subnets
-    if (exists $data{sharednets}) {
-        ok(ref $data{sharednets} eq 'ARRAY' || ref $data{sharednets} eq 'HASH',
-           'sharednets structure parsed');
+# =========================================================================
+# KEA format detection
+# =========================================================================
+subtest 'is_kea_dhcpconf detection' => sub {
+    my $isc_conf = "$testdata/dhcpd.conf";
+    my $kea_conf = "$testdata/kea-dhcp.json";
+    plan skip_all => "KEA/ISC fixtures not found" unless -r $isc_conf && -r $kea_conf;
+
+    ok(!is_kea_dhcpconf($isc_conf), 'ISC dhcpd.conf is not detected as KEA');
+    ok(is_kea_dhcpconf($kea_conf), 'KEA JSON is detected');
+};
+
+# =========================================================================
+# process_kea_dhcpconf - v4
+# =========================================================================
+subtest 'process_kea_dhcpconf v4' => sub {
+    my $conf_file = "$testdata/kea-dhcp.json";
+    plan skip_all => "test/kea-dhcp.json not found" unless -r $conf_file;
+
+    my %data;
+    process_kea_dhcpconf($conf_file, \%data, 0);
+
+    ok(exists $data{'shared-network'}{'kea-lab'}, 'shared-network imported from KEA');
+    ok(exists $data{subnet}{'10.250.1.0 netmask 255.255.255.0'}, 'KEA subnet converted to netmask format');
+    ok(exists $data{pool}{'pool-1'}, 'KEA pool imported');
+    ok(exists $data{host}{'kea-ws1.middle.earth'}, 'KEA reservation imported as host');
+
+    like(join("\n", @{$data{GLOBAL}}),
+        qr/option domain-name-servers ns1\.middle\.earth,ns2\.middle\.earth;/,
+        'KEA global option converted');
+    like(join("\n", @{$data{subnet}{'10.250.1.0 netmask 255.255.255.0'}}),
+        qr/^VLAN kea-lab/m,
+        'subnet bound to shared-network via VLAN marker');
+    like($data{pool}{'pool-1'}->[0],
+        qr/^range 10\.250\.1\.100 10\.250\.1\.110;/,
+        'pool range converted to ISC-like syntax');
+    like(join("\n", @{$data{host}{'kea-ws1.middle.earth'}}),
+        qr/hardware ethernet 00:30:40:50:60:70;/,
+        'host hardware address retained');
+};
+
+# =========================================================================
+# process_kea_dhcpconf - v6
+# =========================================================================
+subtest 'process_kea_dhcpconf v6' => sub {
+    my $conf_file = "$testdata/kea-dhcp.json";
+    plan skip_all => "test/kea-dhcp.json not found" unless -r $conf_file;
+
+    my %data;
+    process_kea_dhcpconf($conf_file, \%data, 1);
+
+    ok(exists $data{subnet6}{'2001:db8:250::/64'}, 'KEA DHCPv6 subnet imported');
+    ok(exists $data{pool6}{'pool6-1'}, 'KEA DHCPv6 pool imported');
+    ok(exists $data{host}{'kea-host6.middle.earth'}, 'KEA DHCPv6 reservation imported as host');
+
+    like($data{pool6}{'pool6-1'}->[0],
+        qr/^range6 2001:db8:250::100 2001:db8:250::1ff;/,
+        'DHCPv6 pool converted to range6 syntax');
+    like(join("\n", @{$data{host}{'kea-host6.middle.earth'}}),
+        qr/fixed-address6 2001:db8:250::10;/,
+        'DHCPv6 fixed address retained');
+    like(join("\n", @{$data{host}{'kea-host6.middle.earth'}}),
+        qr/host-identifier option dhcp6\.client-id 00:03:00:01:00:11:22:33:44:55;/,
+        'DUID normalized for import-dhcp parser');
+};
+
+# =========================================================================
+# process_kea_dhcpconf - class null-safety
+# =========================================================================
+subtest 'process_kea_dhcpconf class non-string test ignored' => sub {
+        my ($fh, $tmpfile) = tempfile();
+        print {$fh} <<'JSON';
+{
+    "Dhcp4": {
+        "client-classes": [
+            {
+                "name": "non-string-test",
+                "test": {"invalid": true}
+            }
+        ]
     }
+}
+JSON
+        close $fh;
+
+        my %data;
+        process_kea_dhcpconf($tmpfile, \%data, 0);
+
+        ok(exists $data{class}{'non-string-test'}, 'class record is imported');
+        is_deeply($data{class}{'non-string-test'}, [], 'non-string class test does not produce match-if line');
 };
 
 done_testing();

--- a/t/11-import-generate.t
+++ b/t/11-import-generate.t
@@ -47,6 +47,15 @@ subtest 'import-dhcp' => sub {
     is($? >> 8, 0, "import-dhcp exits 0") or diag($out);
 };
 
+subtest 'import-dhcp KEA' => sub {
+    my $conf = "$testdata/kea-dhcp.json";
+    plan skip_all => 'test/kea-dhcp.json not found' unless -r $conf;
+
+    my $cmd = "$install_dir/import-dhcp --kea --global example $conf 2>&1";
+    my $out = `$cmd`;
+    is($? >> 8, 0, "import-dhcp --kea exits 0") or diag($out);
+};
+
 # =========================================================================
 # generate configs (bind, dhcp, dhcp6)
 # =========================================================================

--- a/test/kea-dhcp.json
+++ b/test/kea-dhcp.json
@@ -1,0 +1,59 @@
+{
+  "Dhcp4": {
+    "option-data": [
+      {
+        "name": "domain-name-servers",
+        "data": "ns1.middle.earth,ns2.middle.earth"
+      }
+    ],
+    "shared-networks": [
+      {
+        "name": "kea-lab",
+        "subnet4": [
+          {
+            "subnet": "10.250.1.0/24",
+            "option-data": [
+              {
+                "name": "routers",
+                "data": "10.250.1.1"
+              }
+            ],
+            "pools": [
+              {
+                "pool": "10.250.1.100 - 10.250.1.110"
+              }
+            ],
+            "reservations": [
+              {
+                "hostname": "kea-ws1.middle.earth",
+                "hw-address": "00:30:40:50:60:70",
+                "ip-address": "10.250.1.10"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "Dhcp6": {
+    "subnet6": [
+      {
+        "subnet": "2001:db8:250::/64",
+        "pools": [
+          {
+            "pool": "2001:db8:250::100 - 2001:db8:250::1ff"
+          }
+        ],
+        "reservations": [
+          {
+            "hostname": "kea-host6.middle.earth",
+            "duid": "00030001001122334455",
+            "ip-addresses": [
+              "2001:db8:250::10"
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Add process_kea_dhcpconf() and is_kea_dhcpconf() functions to Sauron::UtilDhcp for parsing KEA JSON configuration files (both DHCPv4 and DHCPv6).

- Auto-detect KEA format in import-dhcp script
- Convert subnets, pools, reservations, shared-networks, client-classes and options to ISC-like internal format
- Normalize DUID hex sequences for DHCPv6 host identifiers
- Add tests and KEA JSON fixture
- Update CI dependencies and documentation