### PR TITLE
Fix UTF-8 mojibake in CGI edit/save flow (backward-compatible)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,15 @@
 0.9.0 (beta)
 
+	- Fixed UTF-8 corruption in CGI edit/save flow (notably zone comments)
+	  where text could degrade to mojibake on repeated updates [svamberg]
+	  - DBI backend now enables pg_enable_utf8 and forces UTF8 client encoding
+	  - CGI request UTF-8 parameter decoding is enabled only when configured
+	    charset is UTF-8 (backward-compatible with legacy non-UTF setups)
+	  - Added compatibility repair path in form handling for common mojibake
+	    patterns in UTF-8 mode
+	  - Added upgrade notes for one-time repair of already corrupted records
+	    (README.upgrade)
+
 	- Added KEA DHCP configuration import support: parses KEA JSON 
 	  configs (DHCPv4/DHCPv6) and converts subnets, pools, reservations, 
 	  shared-networks and options to ISC-like internal format used 

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,9 +7,14 @@
 	    charset is UTF-8 (backward-compatible with legacy non-UTF setups)
 	  - Added compatibility repair path in form handling for common mojibake
 	    patterns in UTF-8 mode
+	  - Added dbcheck encoding detector:
+	    --check=encoding [--mojibake-chars=<chars>] [--mojibake-charset=<enc>]
+	    to scan text columns for likely mojibake patterns generated from
+	    selected diacritics
+	  - dbcheck encoding check now also supports interactive repair when
+	    used with --commit (still non-destructive without --commit)
 	  - Added upgrade notes for one-time repair of already corrupted records
 	    (README.upgrade)
-
 	- Added KEA DHCP configuration import support: parses KEA JSON 
 	  configs (DHCPv4/DHCPv6) and converts subnets, pools, reservations, 
 	  shared-networks and options to ISC-like internal format used 

--- a/README.upgrade
+++ b/README.upgrade
@@ -76,6 +76,18 @@ Recommended configuration for new/updated deployments:
  - SAURON_CHARSET = 'utf-8'
  - BROWSER_CHARSET = 'utf-8'
 
+Detection helper (no DB changes):
+ - dbcheck --check=encoding --verbose --yes
+ - Optional custom character seed:
+   dbcheck --check=encoding --verbose --yes --mojibake-chars='ž,š,ť'
+   (you can also pass a plain string, e.g. --mojibake-chars='žšť')
+ - Optional target charset used for mojibake generation/repair:
+   dbcheck --check=encoding --verbose --yes --mojibake-charset='cp1250'
+
+Optional assisted repair (interactive, requires --commit):
+ - dbcheck --check=encoding --verbose --commit
+ - You can review/edit found rows before applying updates.
+
 If old data is already mojibake-corrupted (for example "Å¾luÅ¥ouÄ\x8DkÃ½"):
  - Run a one-time repair only for affected rows, then verify manually.
  - Example for zone comments (adjust WHERE to your dataset):

--- a/README.upgrade
+++ b/README.upgrade
@@ -61,6 +61,32 @@ If you experience issues during migration:
  4) Consult documentation or file a bug report
 
 
+UTF-8 WEB INPUT/OUTPUT COMPATIBILITY (0.9.0)
+
+Sauron 0.9.0 now supports UTF-8 end-to-end in CGI/DBI path by default
+(DBI with pg_enable_utf8 and UTF-8 request handling when configured charset
+is UTF-8).
+
+Compatibility behavior:
+ - UTF-8 request handling is enabled only when configured CGI charset is UTF-8
+   (SAURON_CHARSET/BROWSER_CHARSET =~ /utf-?8/i).
+ - Legacy non-UTF-8 deployments keep previous behavior.
+
+Recommended configuration for new/updated deployments:
+ - SAURON_CHARSET = 'utf-8'
+ - BROWSER_CHARSET = 'utf-8'
+
+If old data is already mojibake-corrupted (for example "Å¾luÅ¥ouÄ\x8DkÃ½"):
+ - Run a one-time repair only for affected rows, then verify manually.
+ - Example for zone comments (adjust WHERE to your dataset):
+
+   UPDATE zones
+      SET comment = convert_from(convert_to(comment,'LATIN1'),'UTF8')
+    WHERE comment LIKE '%Ã%';
+
+Always run a database backup before mass text repair.
+
+
 
 GENERAL UPGRADE PROCEDURE
 

--- a/Sauron/CGIutil.pm
+++ b/Sauron/CGIutil.pm
@@ -13,6 +13,7 @@ use Sauron::Util;
 use Sauron::BackEnd;
 use Net::IP qw(:PROC);
 use HTML::Entities;
+use Encode qw(encode decode FB_CROAK);
 # use Data::Dumper;
 
 use strict;
@@ -403,6 +404,24 @@ sub remove_whitespace($$) {
     return $val;
 }
 
+# Repair typical UTF-8 mojibake caused by ISO-8859-1 decoding in CGI layer.
+# If conversion is not safe/applicable, keep original value unchanged.
+sub fix_param_utf8($) {
+  my ($val) = @_;
+
+  return $val unless defined $val;
+  return $val if $val eq '';
+  return $val unless ((($main::SAURON_CHARSET // '') =~ /utf-?8/i) ||
+                      (($main::BROWSER_CHARSET // '') =~ /utf-?8/i));
+
+  my $fixed = eval {
+    my $octets = encode('ISO-8859-1', $val, FB_CROAK);
+    decode('UTF-8', $octets, FB_CROAK);
+  };
+
+  return defined $fixed ? $fixed : $val;
+}
+
 #####################################################################
 # form_check_form($prefix,$data,$form)
 #
@@ -470,7 +489,7 @@ sub form_check_form($$$) {
       next unless ($val =~ /^($e)$/);
     }
 
-    $val=param($p);
+    $val=fix_param_utf8(param($p));
     $val="\L$val" if ($rec->{conv} eq 'L');
     $val="\U$val" if ($rec->{conv} eq 'U');
 
@@ -550,8 +569,8 @@ sub form_check_form($$$) {
       $data->{$tag}=$val;
     }
     elsif ($type == 101) {
-      $tmp=param($p);
-      $tmp=param($p."_l") if ($tmp eq '');
+      $tmp=fix_param_utf8(param($p));
+      $tmp=fix_param_utf8(param($p."_l")) if ($tmp eq '');
       return 101 if (form_check_field($rec,$tmp,0) ne '');
       $data->{$tag}=$tmp;
     }
@@ -574,11 +593,11 @@ sub form_check_form($$$) {
 # Remove unnecessary whitespace from indexed input fields.
 # **	  if ($rec->{rows}
 	  param($p."_".$j."_".$k,
-	        remove_whitespace(param($p."_".$j."_".$k),
+	        remove_whitespace(fix_param_utf8(param($p."_".$j."_".$k)),
 				  $rec->{'whitesp'}[$k-1] || ''));
-          $tmp=param($p."_".$j."_".$k);
+          $tmp=fix_param_utf8(param($p."_".$j."_".$k));
           if ($rec->{type}[$k-1] eq 'enum') {
-            $tmp=param($p."_".$j."_".$k."_enum") if ($tmp eq '');
+            $tmp=fix_param_utf8(param($p."_".$j."_".$k."_enum")) if ($tmp eq '');
           }
 	  return 2
 	    if (form_check_field($rec,$tmp,$k) ne '');
@@ -609,9 +628,9 @@ sub form_check_form($$$) {
 	    $new=[];
 	    $$new[$f+1]=2;
 	    for $k (1..$f) {
-	      $tmp=param($p2."_".$k);
+	      $tmp=fix_param_utf8(param($p2."_".$k));
               if ($rec->{type}[$k-1] eq 'enum') {
-                $tmp=param($p2."_".$k."_enum") if ($tmp eq '');
+                $tmp=fix_param_utf8(param($p2."_".$k."_enum")) if ($tmp eq '');
               }
 	      $tmp=($tmp eq 'on' ? 't':'f') if ($type==5 && $k>1);
 	      $$new[$k]=$tmp;
@@ -621,9 +640,9 @@ sub form_check_form($$$) {
 	    for $k (1..$f) {
 	      if (param($p2."_".$k) ne $$list[$ind][$k]) {
 		$$list[$ind][$f+1]=1;
-		$tmp=param($p2."_".$k);
+		$tmp=fix_param_utf8(param($p2."_".$k));
                 if ($rec->{type}[$k-1] eq 'enum') {
-                  $tmp=param($p2."_".$k."_enum") if ($tmp eq '');
+                  $tmp=fix_param_utf8(param($p2."_".$k."_enum")) if ($tmp eq '');
                 }
 		$tmp=($tmp eq 'on' ? 't':'f') if ($type==5 && $k>1);
 		$$list[$ind][$k]=$tmp;
@@ -648,7 +667,7 @@ sub form_check_form($$$) {
       }
     }
     elsif ($type == 6 || $type == 7 || $type == 10) {
-      my $val = param($p);
+      my $val = fix_param_utf8(param($p));
       # Allow empty value if field has empty=>1
       if ($val eq '' && $rec->{empty}) {
         $data->{$tag} = -1;  # Set to -1 for empty optional groups
@@ -660,7 +679,8 @@ sub form_check_form($$$) {
     }
     elsif ($type == 13) { # Textarea (check input) 12 Apr 2017 TVu
 # Some sources say that line breaks in textarea depend on the client.
-	$val =~ s/\r(?=\n)//gms; # cr/nl => nl (for Windows client)
+  $val = fix_param_utf8($val);
+  $val =~ s/\r(?=\n)//gms; # cr/nl => nl (for Windows client)
 	$val =~ s/\r/\n/gms; # cr => nl (for Mac client)
 	my @val_arr = split(/\n/, $val);
 	my @val_arr2;

--- a/Sauron/DB-DBI.pm
+++ b/Sauron/DB-DBI.pm
@@ -67,11 +67,14 @@ sub db_connect2() {
   $user = ($main::DB_USER ? $main::DB_USER : '');
   $password = ($main::DB_PASSWORD ? $main::DB_PASSWORD : '');
 
-  $dbh = DBI->connect($dsn,$user,$password);
+  $dbh = DBI->connect($dsn,$user,$password,{ pg_enable_utf8 => 1 });
   unless ($dbh) {
     error("db_connect() failed: " . $DBI::errstr);
     return 0;
   }
+
+  # Keep DB connection text encoding consistent with CGI UTF-8 handling.
+  $dbh->do("SET client_encoding TO 'UTF8'");
 
   return 1;
 }

--- a/Sauron/Sauron.pm
+++ b/Sauron/Sauron.pm
@@ -45,7 +45,7 @@ sub set_defaults() {
 
   $main::SAURON_DEBUG_MODE = 0;
   $main::SAURON_PRIVILEGE_MODE = 0;
-  $main::SAURON_CHARSET='iso-8859-1';
+  $main::SAURON_CHARSET='utf-8';
   $main::SAURON_PWD_MODE = 1;
   $main::SAURON_DHCP2_MODE = 0;
   $main::SAURON_MAIL_FROM = '';
@@ -279,7 +279,7 @@ sub load_browser_config() {
 
   # set defaults
   $main::BROWSER_MAX = 100;
-  $main::BROWSER_CHARSET = 'iso-8859-1';
+  $main::BROWSER_CHARSET = 'utf-8';
   $main::BROWSER_SHOW_FIELDS = 'huser,location,info,dept';
   $main::BROWSER_HIDE_PRIVATE = 1;
   $main::BROWSER_HIDE_FIELDS = 'huser,location';

--- a/cgi/browser.cgi
+++ b/cgi/browser.cgi
@@ -39,6 +39,7 @@ $0 = $PG_NAME;
 $debug_mode = 0;
 
 load_browser_config();
+$CGI::PARAM_UTF8 = 1 if (($BROWSER_CHARSET // '') =~ /utf-?8/i);
 
 
 #%host_types=(0=>'Any type',1=>'Host',2=>'Delegation',3=>'Plain MX',

--- a/cgi/sauron.cgi
+++ b/cgi/sauron.cgi
@@ -52,6 +52,7 @@ my ($PG_DIR,$PG_NAME) = ($0 =~ /^(.*\/)(.*)$/);
 $0 = $PG_NAME;
 
 load_config();
+$CGI::PARAM_UTF8 = 1 if (($SAURON_CHARSET // '') =~ /utf-?8/i);
 
 my $SAURON_CGI_VER = ' $Revision: 1.204 $ $Date: 2005/01/27 09:24:44 $ ';
 $debug_mode = $SAURON_DEBUG_MODE;

--- a/config.in
+++ b/config.in
@@ -134,8 +134,8 @@ $DB_PASSWORD = "bar";
 # authorization level needed to see host history
 # $ALEVEL_HISTORY = 1;
 
-# specify charset for CGI interface (default is iso-8859-1)
-# $SAURON_CHARSET = 'iso-8859-15';
+# specify charset for CGI interface (default is utf-8)
+# $SAURON_CHARSET = 'utf-8';
 
 # Set this to 1 to enable secure cookies. Note, this may cause problems
 # with some broken browsers, so it's not enabled by default.

--- a/dbcheck
+++ b/dbcheck
@@ -17,6 +17,7 @@ use Sauron::SetupIO;
 use Pod::Usage;
 use File::Temp qw/ tempfile tempdir /;
 use Term::ReadLine;
+use Encode qw(encode decode find_encoding FB_CROAK);
 use open ':locale';
 use strict;
 use warnings;
@@ -30,7 +31,8 @@ my ($sid, $uid, @arr, %dbhash, @chks, %groups, $input, $inter, $rows, $more);
 my ($msg, @titles, %ids, $term, $expl);
 my $entire = "\nEntire transaction was rolled back - database was not changed";
 our ($opt_check, $opt_commit, $opt_groups, $opt_help,
-     $opt_man, $opt_user, $opt_verbose, $opt_yes);
+	$opt_man, $opt_mojibake_chars, $opt_mojibake_charset,
+	$opt_user, $opt_verbose, $opt_yes);
 
 # Pointers to subroutines.
 # 3rd column is:
@@ -48,6 +50,7 @@ my @funcs = (
 
     [ \&get_base_group_dhcp,  \&generic_nofix,        3, 'hosts' ], # ** 2021-??-??
     [ \&get_hosts_missing_values, \&generic_nofix,    3, 'hosts' ],
+	[ \&get_mojibake_encoding, \&fix_mojibake_encoding, 2, 'encoding' ],
 
     [ \&get_int_stat_aliases, \&fix_int_stat_aliases, 2, 'aliases' ],
     [ \&get_ext_stat_aliases, \&generic_nofix,        3, 'aliases' ],
@@ -68,7 +71,9 @@ my @funcs = (
 
 # ------------------------------------------------------------------------------
 # Get and check options.
-GetOptions("check:s", "commit", 'groups', "help", "man", "user=s", "verbose", 'yes') or exit;
+GetOptions("check:s", "commit", 'groups', "help", "man",
+		   "mojibake-chars:s", "mojibake-charset:s",
+		   "user=s", "verbose", 'yes') or exit;
 
 print "dbcheck - Sauron utility to check and fix the Sauron database.\n";
 
@@ -123,6 +128,12 @@ if ($opt_groups || $opt_check eq 'error') {
 
 # Some options to canonical format.
 $opt_commit = $opt_commit ? 1 : 0;
+# Optional: empty string intentionally means "use built-in default chars"
+# in parse_mojibake_chars().
+$opt_mojibake_chars = defined $opt_mojibake_chars ? $opt_mojibake_chars : '';
+$opt_mojibake_charset = $opt_mojibake_charset ? $opt_mojibake_charset : 'ISO-8859-1';
+fatal("Unknown --mojibake-charset '$opt_mojibake_charset'")
+	unless (find_encoding($opt_mojibake_charset));
 $opt_user = $opt_user ? $opt_user : '';
 $opt_verbose = $opt_verbose ? 1 : 0;
 $opt_yes = $opt_yes ? 1 : 0;
@@ -483,6 +494,197 @@ sub generic_nofix($) {
 
     print "These are not fixed automatically\n";
     return 0;
+}
+
+# Convert a user-provided list of local-language characters into a list of
+# UTF-8->Latin1 mojibake fragments that can be searched from DB text fields.
+sub parse_mojibake_chars($) {
+
+	my ($spec) = @_;
+	my (@chars, %seen);
+
+# Default Czech/Slovak-like diacritics if no explicit parameter was given.
+	if (!defined $spec || $spec eq '') {
+		@chars = map { chr($_) } (
+			0x00E1, 0x010D, 0x010F, 0x00E9, 0x011B, 0x00ED, 0x0148,
+			0x00F3, 0x0159, 0x0161, 0x0165, 0x00FA, 0x016F, 0x00FD,
+			0x017E, 0x00C1, 0x010C, 0x010E, 0x00C9, 0x011A, 0x00CD,
+			0x0147, 0x00D3, 0x0158, 0x0160, 0x0164, 0x00DA, 0x016E,
+			0x00DD, 0x017D
+		);
+	} elsif ($spec =~ /,/) {
+		@chars = split(/,/, $spec);
+		for my $i (0 .. $#chars) {
+			$chars[$i] =~ s/^\s+|\s+$//g;
+		}
+		@chars = grep { $_ ne '' } @chars;
+	} else {
+		@chars = split(//u, $spec);
+		@chars = grep { $_ ne '' } @chars;
+	}
+
+	@chars = grep { !$seen{$_}++ } @chars;
+	return @chars;
+}
+
+# Convert a mojibake value back to UTF-8 by encoding with configured charset
+# and decoding as UTF-8 bytes.
+sub repair_mojibake_value($) {
+
+	my ($val) = @_;
+	my ($octets, $fixed);
+
+	return $val unless defined $val;
+	return $val if $val eq '';
+
+	$octets = eval { encode($opt_mojibake_charset, $val, FB_CROAK) };
+	return $val unless defined $octets;
+
+	$fixed = eval { decode('UTF-8', $octets, FB_CROAK) };
+	return defined $fixed ? $fixed : $val;
+}
+
+# Find text values that contain typical mojibake fragments generated from a
+# list of chars (for example: 'ž' -> 'Å¾').
+sub get_mojibake_encoding($$$) {
+
+	my ($arr, $msg, $titles) = @_;
+	my ($sql, @cols, @rows, @idcol, %bad, @bad, $pattern, $seq, $table, $column,
+		$tq, $cq, $idexpr, $rowid, $val, $bad_part, $preview, $fixed,
+		$fixed_preview, $ind1, $ind2, $enc, $dec);
+
+	${$msg} = "possible mojibake values in text columns (charset $opt_mojibake_charset)";
+	@{$titles} = ('Id', 'Table.Column', 'Row Id', 'Pattern', 'Value', 'Repaired');
+
+	my @chars = parse_mojibake_chars($opt_mojibake_chars);
+
+	for $ind1 (0 .. $#chars) {
+		$enc = eval { encode('UTF-8', $chars[$ind1], FB_CROAK) };
+		next unless defined $enc;
+		$dec = eval { decode($opt_mojibake_charset, $enc, FB_CROAK) };
+		next unless defined $dec;
+		next if $dec eq $chars[$ind1];
+		$bad{$dec} = 1;
+	}
+	return 0 unless %bad;
+
+	@bad = sort { length($b) <=> length($a) } keys %bad;
+	$pattern = join('|', map { quotemeta($_) } @bad);
+
+	$sql = "select table_name, column_name from information_schema.columns " .
+		"where table_schema='public' and " .
+		"data_type = any (array['text','character varying','character']) " .
+		"order by table_name, ordinal_position;";
+	undef @cols;
+	db_query($sql, \@cols);
+	return 0 unless @cols;
+
+	$seq = 0;
+	for $ind1 (0 .. $#cols) {
+		($table, $column) = @{$cols[$ind1]}[0,1];
+
+		$tq = $table;
+		$tq =~ s/"/""/g;
+		$cq = $column;
+		$cq =~ s/"/""/g;
+
+		undef @idcol;
+		$sql = "select 1 from information_schema.columns " .
+			"where table_schema='public' and " .
+			"table_name=" . db_encode_str($table) . " and " .
+			"column_name='id' limit 1;";
+		db_query($sql, \@idcol);
+		$idexpr = @idcol ? '"id"::text' : "'-'";
+
+		undef @rows;
+		$sql = "select $idexpr, \"$cq\"::text " .
+			"from \"$tq\" " .
+			"where \"$cq\" is not null and " .
+			"\"$cq\"::text ~ " . db_encode_str($pattern) . " " .
+			"order by 1;";
+		db_query($sql, \@rows);
+		next unless @rows;
+
+		for $ind2 (0 .. $#rows) {
+			$rowid = defined $rows[$ind2][0] ? $rows[$ind2][0] : '-';
+			$val = defined $rows[$ind2][1] ? $rows[$ind2][1] : '';
+			$fixed = repair_mojibake_value($val);
+			next if ($fixed eq $val);
+
+			$bad_part = '';
+			for my $bp (@bad) {
+				if (index($val, $bp) >= 0) {
+					$bad_part = $bp;
+					last;
+				}
+			}
+
+			$preview = $val;
+			$preview =~ s/\r?\n/ /g;
+			$preview =~ s/\s{2,}/ /g;
+			if (length($preview) > 120) {
+				$preview = substr($preview, 0, 117) . '...';
+			}
+
+			$fixed_preview = $fixed;
+			$fixed_preview =~ s/\r?\n/ /g;
+			$fixed_preview =~ s/\s{2,}/ /g;
+			if (length($fixed_preview) > 120) {
+				$fixed_preview = substr($fixed_preview, 0, 117) . '...';
+			}
+
+			push @{$arr}, [ ++$seq, "$table.$column", $rowid, $bad_part, $preview,
+							$fixed_preview, $table, $column, $rowid, $fixed ];
+		}
+	}
+
+	return @{$arr} || 0;
+}
+
+# Apply mojibake repair for items selected by get_mojibake_encoding.
+sub fix_mojibake_encoding($) {
+
+	my ($arr) = @_;
+	my ($ind1, $table, $column, $rowid, $new_value, $tq, $cq, $sql, $res,
+		$count, $skip);
+
+	for $ind1 (0 .. $#{$arr}) {
+# Skip items marked as keepers.
+		next if (${$arr}[$ind1][0] eq 'N');
+
+		($table, $column, $rowid, $new_value) =
+			@{${$arr}[$ind1]}[6, 7, 8, 9];
+
+# Only rows with numeric id can be safely updated.
+		unless (defined $rowid && $rowid =~ /^\d+$/) {
+			$skip++;
+			next;
+		}
+
+		$tq = $table;
+		$tq =~ s/"/""/g;
+		$cq = $column;
+		$cq =~ s/"/""/g;
+
+		$sql = "update \"$tq\" set \"$cq\"=" . db_encode_str($new_value) .
+			" where id=$rowid;";
+		$res = db_exec($sql);
+		if ($res < 0) {
+			db_rollback();
+			fatal("Error $res while updating mojibake value in $table.$column (id=$rowid)");
+		}
+		$count++;
+	}
+
+	if ($opt_commit) {
+		print "Updated $count mojibake values\n";
+	} else {
+		print "Would have updated $count mojibake values\n";
+	}
+	if ($skip) {
+		print "Skipped $skip rows without numeric id\n";
+	}
+	return $count || 0;
 }
 
 # Update a column in a table to remove erroneous references.
@@ -1387,6 +1589,18 @@ No checks are done, no matter what other options were given.
 
 Shows this information.
 
+=item --mojibake-chars=<chars-or-comma-list>
+
+Used by C<--check=encoding> to generate expected mojibake fragments from given
+characters and search all public text columns for these fragments. You can pass
+either a plain character string (e.g. C<žšť>) or a comma-separated list
+(e.g. C<ž,š,ť>). If omitted, a default Czech/Slovak diacritics set is used.
+
+=item --mojibake-charset=<encoding>
+
+Charset used to generate and repair mojibake fragments in C<--check=encoding>.
+Default is C<ISO-8859-1>. Example values: C<ISO-8859-1>, C<cp1250>.
+
 =item --user=<username>
 
 Your login username. Used to write Sauron history. Must be known to Sauron.
@@ -1444,6 +1658,16 @@ dbcheck --commit --yes
 
 Safe default checks and fixes only. Summary report. Fixes committed to the
 database, no questions asked.
+
+dbcheck --check=encoding --verbose --mojibake-chars=ž,š,ť
+
+Search for probable mojibake based on listed diacritics. Reports matching rows;
+does not modify database.
+
+dbcheck --check=encoding --verbose --commit --mojibake-chars=ž,š,ť
+
+Search and offer interactive repair of matching mojibake rows. Use with care
+and always keep a recent database backup.
 
 =head1 AUTHORS
 


### PR DESCRIPTION
- Enable UTF-8 handling in DBI connection and enforce UTF8 client encoding.
- Decode CGI request parameters as UTF-8 only when configured charset is UTF-8.
- Add guarded form-input mojibake repair for UTF-8 mode to prevent repeated text degradation.
- Preserve legacy non-UTF deployments by keeping new decoding/repair logic conditional.
- Set UTF-8 as default web charset and update config template comments.
- Document upgrade and one-time historical data repair procedure.
- Update ChangeLog with root cause, fix scope, and compatibility notes.
- dbcheck: add configurable mojibake scan and optional repair