### PR TITLE
Fix catalog zone owner names to avoid duplicated label

### DIFF
--- a/import-catalog-zone
+++ b/import-catalog-zone
@@ -150,6 +150,10 @@ print "Detected source catalog origin: $source_origin\n" if ($opt_verbose);
 #
 # Structure:
 #   version.catalog.<origin>  TXT "2"
+#   <uuid>.zones.<origin>  PTR <member-zone-name>.
+#   group.<uuid>.zones.<origin>  TXT "<group-name>"
+#
+# Legacy Sauron format also accepted:
 #   <uuid>.zones.catalog.<origin>  PTR <member-zone-name>.
 #   group.<uuid>.zones.catalog.<origin>  TXT "<group-name>"
 
@@ -168,17 +172,18 @@ if ($zonedata{$version_key} && @{$zonedata{$version_key}{TXT}} > 0) {
 }
 
 # Extract member zones and group assignments
-# Sauron generator uses 'uuid-xxx.zones.catalog' and 'group.uuid-xxx.zones.catalog'
-# relative to zone origin, expanding to '*.zones.catalog.<origin>'.
+# Accept both RFC 9432 canonical names (*.zones.<origin>) and
+# legacy Sauron names (*.zones.catalog.<origin>).
 %members = ();  # uuid => { name => 'zone.name', groups => ['g1', ...] }
-$zones_suffix = "zones.catalog.$source_origin";
+$member_re = qr/^([^.]+)\.zones(?:\.catalog)?\.\Q$source_origin\E$/i;
+$group_re = qr/^group\.([^.]+)\.zones(?:\.catalog)?\.\Q$source_origin\E$/i;
 
 foreach $domain (keys %zonedata) {
     my $rec = $zonedata{$domain};
 
-    # Match PTR records under *.zones.catalog.<origin>
-    # Format: <uuid>.zones.catalog.<origin> PTR <member-zone>.
-    if ($domain =~ /^([^.]+)\.\Q$zones_suffix\E$/i && @{$rec->{PTR}} > 0) {
+    # Match PTR records under *.zones.<origin> (and legacy *.zones.catalog.<origin>)
+    # Format: <uuid>.zones.<origin> PTR <member-zone>.
+    if ($domain =~ $member_re && @{$rec->{PTR}} > 0) {
 	my $uuid = $1;
 	my $member_name = $rec->{PTR}[0];
 	$member_name =~ s/\.$//;  # strip trailing dot
@@ -188,10 +193,10 @@ foreach $domain (keys %zonedata) {
 	next;
     }
 
-    # Match group TXT records: group.<uuid>.zones.catalog.<origin>
-    # Format: group.<uuid>.zones.catalog.<origin> TXT "<group-name>"
+    # Match group TXT records: group.<uuid>.zones.<origin>
+    # Legacy form group.<uuid>.zones.catalog.<origin> is also accepted.
     if (!$opt_ignore_groups &&
-	$domain =~ /^group\.([^.]+)\.\Q$zones_suffix\E$/i && @{$rec->{TXT}} > 0) {
+	$domain =~ $group_re && @{$rec->{TXT}} > 0) {
 	my $uuid = $1;
 	$members{$uuid} = { name => '', groups => [] }
 	    unless ($members{$uuid});

--- a/sauron
+++ b/sauron
@@ -1733,13 +1733,13 @@ sub make_dns() {
           my $member_groups = $catalog_rec->{members}[$i][7];
           $member_zone =~ s/\.$//;  # Remove trailing dot
 
-          printf ZONEFILE $ZFORMAT, "uuid-$member_id.zones.catalog",$ttl,'IN','PTR',"$member_zone."
+          printf ZONEFILE $ZFORMAT, "uuid-$member_id.zones",$ttl,'IN','PTR',"$member_zone."
             if ($bind_conf);
 
           # Group property TXT records (RFC 9432 §5.2)
           if ($bind_conf && ref($member_groups) eq 'ARRAY') {
             for my $grp (@{$member_groups}) {
-              printf ZONEFILE $ZFORMAT, "group.uuid-$member_id.zones.catalog",
+              printf ZONEFILE $ZFORMAT, "group.uuid-$member_id.zones",
                   $ttl,'IN','TXT',"\"$grp\"";
             }
           }
@@ -1789,13 +1789,13 @@ sub make_dns() {
             $seen_names{$lc_name} = "$src_name (prio=$prio)";
 
             printf ZONEFILE $ZFORMAT,
-                "uuid-$mzone_id.zones.catalog",
+                "uuid-$mzone_id.zones",
                 $ttl, 'IN', 'PTR', "$mzone_name.";
 
             if (ref($mgroups) eq 'ARRAY') {
               for my $grp (@{$mgroups}) {
                 printf ZONEFILE $ZFORMAT,
-                    "group.uuid-$mzone_id.zones.catalog",
+                    "group.uuid-$mzone_id.zones",
                     $ttl, 'IN', 'TXT', "\"$grp\"";
               }
             }

--- a/t/13-catalog-aggregate.t
+++ b/t/13-catalog-aggregate.t
@@ -383,9 +383,9 @@ subtest 'generate aggregate zone file' => sub {
     # Find the uuid for shared's PTR line and check its group
     my $shared_zone_id = get_zone_id('shared.example.com', $serverid);
     if ($shared_zone_id > 0) {
-        like($content, qr/uuid-$shared_zone_id\.zones\.catalog\s+.*\s+PTR\s+shared\.example\.com\./,
+          like($content, qr/uuid-$shared_zone_id\.zones\s+.*\s+PTR\s+shared\.example\.com\./,
              'shared uses correct uuid in aggregate');
-        like($content, qr/group\.uuid-$shared_zone_id\.zones\.catalog\s+.*\s+TXT\s+"shared-group"/,
+          like($content, qr/group\.uuid-$shared_zone_id\.zones\s+.*\s+TXT\s+"shared-group"/,
              'shared group from catalog1 (priority 10) wins');
     }
 
@@ -450,10 +450,10 @@ $ORIGIN catalog1.example.com.
 		2024020101 3600 900 604800 0 )
 	IN	NS	invalid.
 version.catalog		IN	TXT	"2"
-uuid-002.zones.catalog	IN	PTR	beta.example.com.
-uuid-003.zones.catalog	IN	PTR	shared.example.com.
-group.uuid-002.zones.catalog	IN	TXT	"backend"
-group.uuid-003.zones.catalog	IN	TXT	"shared-group"
+uuid-002.zones	IN	PTR	beta.example.com.
+uuid-003.zones	IN	PTR	shared.example.com.
+group.uuid-002.zones	IN	TXT	"backend"
+group.uuid-003.zones	IN	TXT	"shared-group"
 ZONE
     close($fh);
 
@@ -503,9 +503,9 @@ $ORIGIN catalog1.example.com.
 		2024030101 3600 900 604800 0 )
 	IN	NS	invalid.
 version.catalog		IN	TXT	"2"
-uuid-002.zones.catalog	IN	PTR	beta.example.com.
-uuid-003.zones.catalog	IN	PTR	shared.example.com.
-uuid-004.zones.catalog	IN	PTR	newzone.example.com.
+uuid-002.zones	IN	PTR	beta.example.com.
+uuid-003.zones	IN	PTR	shared.example.com.
+uuid-004.zones	IN	PTR	newzone.example.com.
 ZONE
     close($fh);
 
@@ -595,7 +595,7 @@ subtest 'generate after priority swap - conflict winner changes' => sub {
     # With catalog1 at priority=1 (wins), shared's group should be from catalog1
     my $shared_zid = get_zone_id('shared.example.com', $serverid);
     if ($shared_zid > 0) {
-        like($content, qr/group\.uuid-$shared_zid\.zones\.catalog\s+.*\s+TXT\s+"shared-group"/,
+        like($content, qr/group\.uuid-$shared_zid\.zones\s+.*\s+TXT\s+"shared-group"/,
              'shared group from catalog1 (now priority=1) wins');
     }
 };
@@ -676,10 +676,10 @@ $ORIGIN catalog1.example.com.
 		2024040101 3600 900 604800 0 )
 	IN	NS	invalid.
 version.catalog		IN	TXT	"2"
-uuid-002.zones.catalog	IN	PTR	beta.example.com.
-uuid-003.zones.catalog	IN	PTR	shared.example.com.
-group.uuid-002.zones.catalog	IN	TXT	"should-be-ignored"
-group.uuid-003.zones.catalog	IN	TXT	"should-be-ignored"
+uuid-002.zones	IN	PTR	beta.example.com.
+uuid-003.zones	IN	PTR	shared.example.com.
+group.uuid-002.zones	IN	TXT	"should-be-ignored"
+group.uuid-003.zones	IN	TXT	"should-be-ignored"
 ZONE
     close($fh);
 


### PR DESCRIPTION
* Generate RFC 9432 member/group owners under .zones instead of .zones.catalog.
* Accept both canonical and legacy owner formats in import-catalog-zone.
* Update catalog aggregate tests to match the canonical format.