### PR TITLE
Fix and extend import-zone-comments

### DIFF
--- a/import-zone-comments
+++ b/import-zone-comments
@@ -585,7 +585,7 @@ sub comment_soa($) {
 # import_comments
 # ---------------
 sub import_comments($$$) {
-  my ($data, $server, $zone) = shift @_;
+  my ($data, $server, $zone) = @_;
   my ($rec, $res, $ret, $sql, $comment, $blcomment);
 
   #print "$data\n";
@@ -629,13 +629,14 @@ sub import_comments($$$) {
     }
     elsif ($$rec{rtype} eq 'MX' and $$rec{owner}) {
       my ($mx_pref, $mx_exchange) = split /\s+/, $$rec{rdata};
+      my $host_id = get_host_id($zoneid, $$rec{owner});
       $sql = qq{
           UPDATE mx_entries
              SET comment = $comment
-           WHERE zone   = '$zoneid'
-             AND domain = '$$rec{owner}'
-             AND pref   = '$mx_pref'
-             AND exchange = '$mx_exchange'
+           WHERE ref  = '$host_id'
+             AND type = '2'
+             AND pri  = '$mx_pref'
+             AND mx   = '$mx_exchange'
              AND (comment IS NULL OR comment = '')
       };
       db_exec($sql) unless $opt_noop;

--- a/import-zone-comments
+++ b/import-zone-comments
@@ -695,6 +695,22 @@ sub import_comments($$$) {
       db_exec($sql) unless $opt_noop;
       print "db_exec: $sql\n" if $opt_verbose;
     }
+    elsif ($$rec{rtype} eq 'TLSA' and $$rec{owner}) {
+      my ($tlsa_usage, $tlsa_selector, $tlsa_mt, $tlsa_data) = split /\s+/, $$rec{rdata};
+      my $host_id = get_host_id($zoneid, $$rec{owner});
+      $sql = qq{
+        UPDATE tlsa_entries
+           SET comment     = $comment
+         WHERE ref         = '$host_id'
+           AND usage       = '$tlsa_usage'
+           AND selector    = '$tlsa_selector'
+           AND matching_type = '$tlsa_mt'
+           AND association_data = '$tlsa_data'::bytea
+           AND (comment IS NULL OR comment = '')
+      };
+      db_exec($sql) unless $opt_noop;
+      print "db_exec: $sql\n" if $opt_verbose;
+    }
     elsif ($$rec{rtype} eq 'NAPTR' and $$rec{owner}) {
       my ($naptr_order, $naptr_preference, $naptr_flags, $naptr_service, $naptr_regexp, $naptr_replacement) = split /\s+/, $$rec{rdata};
       $naptr_flags =~ tr/a-z/A-Z/;  # flags are case-insensitive, but we store them in uppercase

--- a/import-zone-comments
+++ b/import-zone-comments
@@ -97,8 +97,8 @@ my $grammar = <<'GRAMMAR';
 {
     # Global variables used by the parser during processing
     my $zone        = { records => [] };
-    my $prev_owner  = '';
-    my $origin      = '';        # last $ORIGIN (for @)
+    my $prev_owner  = '@';     # Default owner for records without explicit owner (zone apex)
+    my $origin      = '';      # last $ORIGIN (for @)
 
     sub _push { push @{ $zone->{records} }, $_[0] }
 }
@@ -148,6 +148,7 @@ directive:
 origin_directive:
         /\$ORIGIN/ domain'.' comment(?) {
             $origin = $item[2]->{name} . '.';
+            $prev_owner = $origin;  # Update default owner for records without explicit owner
             my $rec = {
                 type      => 'directive',
                 directive => 'ORIGIN',
@@ -177,10 +178,60 @@ rr_line:
         rr ws(?) eol                { $return = $item[1] }
 
 rr:
-        owner(?) ttl(?) class(?) type rdata ws(?) comment(?) {
-            # If there is no explicit owner, use the previous one
-            my $owner = $item[1][0];
-            $owner = $prev_owner unless $owner;
+        # Case 1: Record WITHOUT owner - starts with TTL (number CLASS? TYPE RDATA) - MUST BE FIRST!
+        number class(?) type rdata ws(?) comment(?) {
+            my $owner = $prev_owner;
+
+            my $rec = {
+                type    => 'rr',
+                owner   => $owner,
+                ttl     => $item[1],
+                class   => $item[2][0] ? $item[2][0] : 'IN',
+                rtype   => $item[3],
+                rdata   => $item[4],
+                comment => $item[6][0] ? $item[6][0] : undef,
+                line_nr => $thisline,
+            };
+            _push($rec);
+            $return = $rec;
+        }
+     |  # Case 2: Record WITHOUT owner - starts with CLASS only (CLASS TYPE RDATA)
+        class type rdata ws(?) comment(?) {
+            my $owner = $prev_owner;
+
+            my $rec = {
+                type    => 'rr',
+                owner   => $owner,
+                ttl     => undef,
+                class   => $item[1],
+                rtype   => $item[2],
+                rdata   => $item[3],
+                comment => $item[5][0] ? $item[5][0] : undef,
+                line_nr => $thisline,
+            };
+            _push($rec);
+            $return = $rec;
+        }
+     |  # Case 3: Record WITHOUT owner - starts directly with TYPE (TYPE RDATA)
+        type rdata ws(?) comment(?) {
+            my $owner = $prev_owner;
+
+            my $rec = {
+                type    => 'rr',
+                owner   => $owner,
+                ttl     => undef,
+                class   => 'IN',
+                rtype   => $item[1],
+                rdata   => $item[2],
+                comment => $item[4][0] ? $item[4][0] : undef,
+                line_nr => $thisline,
+            };
+            _push($rec);
+            $return = $rec;
+        }
+     |  # Case 4: Record WITH explicit owner (hostname TTL? CLASS? TYPE RDATA) - MUST BE LAST!
+        ownername ttl(?) class(?) type rdata ws(?) comment(?) {
+            my $owner = $item[1];
             $prev_owner = $owner if $owner;
 
             my $rec = {
@@ -200,16 +251,14 @@ rr:
 
 # ---------------------------  TOKENS -----------------------
 owner:
-        ownername ...type_exists  {
+        ownername {
             my $val = $item[1];
             # list of allowed classes – same as CLASS
             my %classes = map { $_ => 1 } qw( IN CH HS );
-            if ( $classes{$val} ) {
-                # The class was assigned instead of the owner -> we will reject it.
+            if ( defined $val && $classes{$val} ) {
+                # The class was assigned instead of the owner -> reject
                 $::RD_HINT && warn "owner '$val' looks like a CLASS – rejected\n";
-                # we return undef and thus "reject"
                 $return = undef;
-                # (alternatively, you can use $parser->reject; or die)
             }
             else {
                 $return = $val;
@@ -286,7 +335,14 @@ name:       /[A-Za-z0-9\-_]+(?:\.[A-Za-z0-9\-_]+)*/   { $return = $item[1] }
 ownername:  name'.'     { $return = $item[1] }
       |     '*.'name    { $return = $item[1] }
       |     '*.'name'.' { $return = $item[1] }
-      |     name        { $return = $item[1] }
+      |     name        { 
+          # Reject pure numeric values (they are TTLs, not hostnames)
+          if ( $item[1] =~ /^\d+$/ ) {
+              $return = undef;
+          } else {
+              $return = $item[1];
+          }
+      }
 
 domain:     name
 
@@ -552,7 +608,11 @@ sub import_comments($$$) {
     
     next unless ($$rec{comment} or $blcomment); # blokovy ani radkovy komentar
 
-    #print "$i: $$rec{type} $$rec{owner} -> $$rec{class} -> $$rec{rtype}\n"; 
+    # Skip records without owner (safety check)
+    if (!$$rec{owner}) {
+        next;
+    }
+
     $comment = db_encode_str($$rec{comment} ? $$rec{comment} : $blcomment);
     
     if ($$rec{rtype} =~ /^(A|AAAA)$/ and $$rec{owner}) {
@@ -567,6 +627,20 @@ sub import_comments($$$) {
       print "db_exec: $sql\n" if $opt_verbose;
       db_exec($sql) unless $opt_noop;
     }
+    elsif ($$rec{rtype} eq 'MX' and $$rec{owner}) {
+      my ($mx_pref, $mx_exchange) = split /\s+/, $$rec{rdata};
+      $sql = qq{
+          UPDATE mx_entries
+             SET comment = $comment
+           WHERE zone   = '$zoneid'
+             AND domain = '$$rec{owner}'
+             AND pref   = '$mx_pref'
+             AND exchange = '$mx_exchange'
+             AND (comment IS NULL OR comment = '')
+      };
+      db_exec($sql) unless $opt_noop;
+      print "db_exec: $sql\n" if $opt_verbose;
+    }
     elsif ($$rec{rtype} eq 'CNAME' and $$rec{owner}) {
       $sql = qq{
           UPDATE hosts
@@ -579,7 +653,7 @@ sub import_comments($$$) {
       db_exec($sql) unless $opt_noop;
       print "db_exec: $sql\n" if $opt_verbose;
     }
-    elsif ($$rec{rtype} eq 'TXT' and $$rec{owner} =~ /\w+/) {
+    elsif ($$rec{rtype} eq 'TXT' and ($$rec{owner} eq '@' or $$rec{owner} =~ /\w+/)) {
       # TXT in zone entries 
       $sql = qq{
           UPDATE txt_entries


### PR DESCRIPTION
This pull request fixes several bugs in the `import-zone-comments` script and adds support for importing comments on additional DNS record types (MX and TLSA).

1. **Fix DNS record parsing for entries without explicit owner**

   The script failed to parse zone files where subsequent records omit the owner field and inherit it from the previous record (e.g. `3600 IN MX …` or `IN TXT …`). The grammar rules have been restructured with four alternative `rr` rules (ordered from most to least specific) to correctly handle records starting with TTL, CLASS, TYPE, or an explicit ownername. The previous owner is now initialized to `@` (zone apex) and updated on `$ORIGIN` directives.

2. **Fix `import_comments()` parameter passing and MX record SQL**

   `import_comments()` was only receiving the first argument (`$data`) because of incorrect `shift @_` usage. Fixed to use `@_` so all three parameters (`$data`, `$server`, `$zone`) are correctly received. Also fixed the MX record SQL query to use correct `mx_entries` columns (`ref`, `type`, `pri`, `mx`) and consistent `host_id` retrieval via `get_host_id()`.

3. **Add TLSA record comment import support**

   TLSA records were previously reported as "unknown record" and their comments were skipped. Added a dedicated branch in `import_comments()` that matches TLSA records against the `tlsa_entries` table using `usage`, `selector`, `matching_type`, and `association_data` (with a PostgreSQL `bytea` cast for proper matching against the `BYTEA` column).

