### PR TITLE
Fix HTML entity encoding in pending zones display

### DIFF
--- a/Sauron/CGI/Zones.pm
+++ b/Sauron/CGI/Zones.pm
@@ -697,7 +697,7 @@ sub menu_handler {
     # check for removed hosts...
     get_zone($zoneid,\%zone);
     if ($zone{rdate} > $zone{serial_date}) {
-      push @plist, ['','<removed host(s)>','',
+      push @plist, ['','<removed host(s)>','','Remove',
 		    localtime($zone{rdate}).'',''];
     }
 

--- a/Sauron/CGI/Zones.pm
+++ b/Sauron/CGI/Zones.pm
@@ -697,7 +697,7 @@ sub menu_handler {
     # check for removed hosts...
     get_zone($zoneid,\%zone);
     if ($zone{rdate} > $zone{serial_date}) {
-      push @plist, ['','&lt;removed host(s)&gt;','',
+      push @plist, ['','<removed host(s)>','',
 		    localtime($zone{rdate}).'',''];
     }
 


### PR DESCRIPTION
Replace hardcoded HTML entities with actual characters in the pending changes list. The display_list() function properly encodes the characters during rendering, so using literal '<' and '>' characters fixes the double-encoding issue that displayed '&lt;removed host(s)&gt;' instead of '<removed host(s)>'.

Fixes rendering on zones/pending page where removed hosts were shown with visible HTML entities instead of actual angle brackets.