### PR TITLE
Enhanced History Logging for Servers and Zones

### DIFF
--- a/Sauron/BackEnd.pm
+++ b/Sauron/BackEnd.pm
@@ -885,6 +885,25 @@ sub diff_records($$$$) {
   $skip_hash{muser} = 1;
   $skip_hash{id} = 1;
 
+  # Helper function to extract values from array fields (skip header row and deleted entries)
+  sub extract_array_values {
+    my($arr) = @_;
+    return '' unless (ref($arr) eq 'ARRAY');
+    my @vals;
+    for my $row (@{$arr}) {
+      next unless (ref($row) eq 'ARRAY');
+      # Skip header row (first element is not a number)
+      my $id = $$row[0];
+      next unless (defined($id) && $id =~ /^-?\d+$/);
+      # Skip entries marked for deletion (state = -1 in last column)
+      my $state = $$row[$#{$row}];
+      next if (defined($state) && $state eq '-1');
+      # Extract value from second column (index 1)
+      push @vals, $$row[1] if (defined($$row[1]) && $$row[1] ne '');
+    }
+    return join(',', @vals);
+  }
+
   foreach my $key (keys %{$new_rec}) {
     next if $skip_hash{$key};
     next unless defined($$new_rec{$key});
@@ -894,8 +913,8 @@ sub diff_records($$$$) {
 
     # Handle array fields (lists)
     if ($arr_hash{$key}) {
-      my $old_str = (ref($old_val) eq 'ARRAY' ? join(',', map { $_->[1] // '' } @{$old_val}) : $old_val);
-      my $new_str = (ref($new_val) eq 'ARRAY' ? join(',', map { $_->[1] // '' } @{$new_val}) : $new_val);
+      my $old_str = extract_array_values($old_val);
+      my $new_str = extract_array_values($new_val);
       $old_str =~ s/^\s+|\s+$//g;
       $new_str =~ s/^\s+|\s+$//g;
       if ($old_str ne $new_str) {

--- a/Sauron/BackEnd.pm
+++ b/Sauron/BackEnd.pm
@@ -1099,7 +1099,6 @@ sub update_server($) {
   $id=$rec->{id};
 
   # Compute changes for history log
-  my $server_name = $rec->{name} || "ID=$id";
   $changes = diff_records(\%old_rec, $rec, 
                           'cdate_str,mdate_str,pending_info,zonehostid',
                           'allow_transfer,allow_query,allow_recursion,blackhole,listen_on,listen_on_v6,forwarders,dhcp,dhcp_l,dhcp6,dhcp6_l,txt,logging,custom_opts,bind_globals,allow_query_cache,allow_notify');

--- a/Sauron/BackEnd.pm
+++ b/Sauron/BackEnd.pm
@@ -886,6 +886,7 @@ sub diff_records($$$$) {
   $skip_hash{id} = 1;
 
   # Helper function to extract values from array fields (skip header row and deleted entries)
+  # For multi-column fields (like MX with priority), include all relevant columns
   sub extract_array_values {
     my($arr) = @_;
     return '' unless (ref($arr) eq 'ARRAY');
@@ -898,8 +899,25 @@ sub diff_records($$$$) {
       # Skip entries marked for deletion (state = -1 in last column)
       my $state = $$row[$#{$row}];
       next if (defined($state) && $state eq '-1');
-      # Extract value from second column (index 1)
-      push @vals, $$row[1] if (defined($$row[1]) && $$row[1] ne '');
+      # Extract values from columns (skip id at index 0 and state at last index)
+      # For MX: [id, pri, mx, comment, state] -> show "pri:mx" (skip empty comment)
+      # For NS: [id, ns, comment, state] -> show "ns" (skip empty comment)
+      my @row_vals;
+      for my $i (1..$#{$row}-1) {  # Skip first (id) and last (state) columns
+        # Only skip if it's the last non-state column AND it's empty (likely comment)
+        # Otherwise include the value
+        my $is_last_data_col = ($i == $#{$row}-1);
+        my $val = $$row[$i];
+        if (defined($val) && $val ne '') {
+          push @row_vals, $val;
+        } elsif (!$is_last_data_col) {
+          # Include empty string placeholder for non-last columns to preserve structure
+          push @row_vals, '';
+        }
+      }
+      # Clean up: remove trailing empty values (comments)
+      while (@row_vals && $row_vals[-1] eq '') { pop @row_vals; }
+      push @vals, join(':', @row_vals) if (@row_vals > 0);
     }
     return join(',', @vals);
   }

--- a/Sauron/BackEnd.pm
+++ b/Sauron/BackEnd.pm
@@ -868,6 +868,52 @@ sub update_textarea_field($$$$$$) { # Textarea 12 Apr 2017 TVu
 ############################################################################
 # server table functions
 
+# Compare two record hashes and return a string describing the changes.
+# Returns: "field1 (old -> new), field2 ([list])" etc.
+sub diff_records($$$$) {
+  my($old_rec, $new_rec, $skip_fields, $array_fields) = @_;
+  my @changes;
+  my @skip = split(/,/, $skip_fields || '');
+  my %skip_hash = map { $_ => 1 } @skip;
+  my @arr_flds = split(/,/, $array_fields || '');
+  my %arr_hash = map { $_ => 1 } @arr_flds;
+
+  # Skip standard fields that are auto-updated
+  $skip_hash{cdate} = 1;
+  $skip_hash{cuser} = 1;
+  $skip_hash{mdate} = 1;
+  $skip_hash{muser} = 1;
+  $skip_hash{id} = 1;
+
+  foreach my $key (keys %{$new_rec}) {
+    next if $skip_hash{$key};
+    next unless defined($$new_rec{$key});
+
+    my $old_val = (defined($$old_rec{$key}) ? $$old_rec{$key} : '');
+    my $new_val = $$new_rec{$key};
+
+    # Handle array fields (lists)
+    if ($arr_hash{$key}) {
+      my $old_str = (ref($old_val) eq 'ARRAY' ? join(',', map { $_->[1] // '' } @{$old_val}) : $old_val);
+      my $new_str = (ref($new_val) eq 'ARRAY' ? join(',', map { $_->[1] // '' } @{$new_val}) : $new_val);
+      $old_str =~ s/^\s+|\s+$//g;
+      $new_str =~ s/^\s+|\s+$//g;
+      if ($old_str ne $new_str) {
+        push @changes, "$key (" . ($old_str eq '' ? '[]' : $old_str) . " -> " . 
+                       ($new_str eq '' ? '[]' : $new_str) . ")";
+      }
+    }
+    # Handle simple scalar values
+    elsif (!ref($old_val) && !ref($new_val)) {
+      if ($old_val ne $new_val) {
+        push @changes, "$key ('$old_val' -> '$new_val')";
+      }
+    }
+  }
+
+  return join(', ', @changes);
+}
+
 sub get_server_id($) {
   my ($server) = @_;
   my (@q);
@@ -978,7 +1024,10 @@ sub get_server($$) {
 
 sub update_server($) {
   my($rec) = @_;
-  my($r,$id);
+  my($r,$id,%old_rec,$changes);
+
+  # Load original server record for history diff
+  get_server($rec->{id}, \%old_rec) if ($rec->{id} > 0);
 
   del_std_fields($rec);
   delete $rec->{dhcp_flags};
@@ -1011,6 +1060,12 @@ sub update_server($) {
   $r=update_record('servers',$rec);
   if ($r < 0) { db_rollback(); return $r; }
   $id=$rec->{id};
+
+  # Compute changes for history log
+  my $server_name = $rec->{name} || "ID=$id";
+  $changes = diff_records(\%old_rec, $rec, 
+                          'cdate_str,mdate_str,pending_info,zonehostid',
+                          'allow_transfer,allow_query,allow_recursion,blackhole,listen_on,listen_on_v6,forwarders,dhcp,dhcp_l,dhcp6,dhcp6_l,txt,logging,custom_opts,bind_globals,allow_query_cache,allow_notify');
 
   # allow_transfer
   $r=update_aml_field(1,$id,$rec,'allow_transfer');
@@ -1082,7 +1137,9 @@ sub update_server($) {
 
   # Log server update to history (before commit)
   my $server_name = $rec->{name} || "ID=$id";
-  update_history($muid, $msid, 3, "EDIT: Server", "name: $server_name", $id);
+  my $info_str = "name: $server_name";
+  $info_str .= " | Changes: $changes" if ($changes);
+  update_history($muid, $msid, 3, "EDIT: Server", $info_str, $id);
 
   return db_commit();
 }
@@ -1630,8 +1687,11 @@ sub get_zone($$) {
 
 sub update_zone($) {
   my($rec) = @_;
-  my($r,$id,$new_net,$hid);
+  my($r,$id,$new_net,$hid,%old_rec,$changes);
   my(@current_catalogs, @new_catalogs, %new_cat_hash, %current_cat_hash);
+
+  # Load original zone record for history diff
+  get_zone($rec->{id}, \%old_rec) if ($rec->{id} > 0);
 
   del_std_fields($rec);
   delete $rec->{pending_info};
@@ -1861,9 +1921,16 @@ sub update_zone($) {
     }
   }
 
-  # Log zone update to history (before commit)
+  # Compute changes for history log
   my $zone_name = $rec->{name} || "ID=$id";
-  update_history($muid, $msid, 2, "EDIT: Zone", "name: $zone_name", $id);
+  $changes = diff_records(\%old_rec, $rec,
+                          'cdate_str,mdate_str,pending_info,zonehostid',
+                          'allow_update,masters,allow_query,allow_transfer,also_notify,forwarders');
+
+  # Log zone update to history (before commit)
+  my $info_str = "name: $zone_name";
+  $info_str .= " | Changes: $changes" if ($changes);
+  update_history($muid, $msid, 2, "EDIT: Zone", $info_str, $id);
 
   return db_commit();
 }

--- a/Sauron/BackEnd.pm
+++ b/Sauron/BackEnd.pm
@@ -1925,7 +1925,7 @@ sub update_zone($) {
   my $zone_name = $rec->{name} || "ID=$id";
   $changes = diff_records(\%old_rec, $rec,
                           'cdate_str,mdate_str,pending_info,zonehostid',
-                          'allow_update,masters,allow_query,allow_transfer,also_notify,forwarders');
+                          'ns,mx,txt,caa,naptr,ip,dhcp,allow_update,masters,allow_query,allow_transfer,also_notify,forwarders,zentries,zentries_ta');
 
   # Log zone update to history (before commit)
   my $info_str = "name: $zone_name";

--- a/Sauron/BackEnd.pm
+++ b/Sauron/BackEnd.pm
@@ -887,7 +887,7 @@ sub diff_records($$$$) {
 
   # Helper function to extract values from array fields (skip header row and deleted entries)
   # For multi-column fields (like MX with priority), include all relevant columns
-  sub extract_array_values {
+  my $extract_array_values = sub {
     my($arr) = @_;
     return '' unless (ref($arr) eq 'ARRAY');
     my @vals;
@@ -920,7 +920,7 @@ sub diff_records($$$$) {
       push @vals, join(':', @row_vals) if (@row_vals > 0);
     }
     return join(',', @vals);
-  }
+  };
 
   foreach my $key (keys %{$new_rec}) {
     next if $skip_hash{$key};
@@ -931,8 +931,8 @@ sub diff_records($$$$) {
 
     # Handle array fields (lists)
     if ($arr_hash{$key}) {
-      my $old_str = extract_array_values($old_val);
-      my $new_str = extract_array_values($new_val);
+      my $old_str = $extract_array_values->($old_val);
+      my $new_str = $extract_array_values->($new_val);
       $old_str =~ s/^\s+|\s+$//g;
       $new_str =~ s/^\s+|\s+$//g;
       if ($old_str ne $new_str) {

--- a/Sauron/BackEnd.pm
+++ b/Sauron/BackEnd.pm
@@ -25,6 +25,7 @@ $VERSION = '$Id:$ ';
 	     sauron_db_version
 	     get_db_version
 	     set_muser
+	     set_muid_msid
 	     auto_address
 	     next_free_ip
 	     ip_in_use
@@ -163,6 +164,8 @@ $VERSION = '$Id:$ ';
 
 	     get_history_host
 	     get_history_session
+	     get_history_zone
+	     get_history_server
 
 	     save_state
 	     load_state
@@ -191,6 +194,7 @@ $VERSION = '$Id:$ ';
 
 # Catalog zones support (RFC 9432) - six functions exported above
 my($muser);
+my($muid, $msid);  # User ID and Session ID for history logging
 
 
 
@@ -225,6 +229,12 @@ sub sauron_db_version() {
 sub set_muser($) {
   my($usr)=@_;
   $muser=$usr;
+}
+
+sub set_muid_msid($$) {
+  my($uid, $sid)=@_;
+  $muid=$uid;
+  $msid=$sid;
 }
 
 
@@ -1070,6 +1080,9 @@ sub update_server($) {
   $r=update_aml_field(16,$id,$rec,'listen_on_v6');
   if ($r < 0) { db_rollback(); return -25; }
 
+  # Log server update to history (before commit)
+  my $server_name = $rec->{name} || "ID=$id";
+  update_history($muid, $msid, 3, "EDIT: Server", "name: $server_name", $id);
 
   return db_commit();
 }
@@ -1147,6 +1160,9 @@ sub add_server($) {
   $res = update_aml_field(15,$id,$rec,'allow_notify');
   if ($res < 0) { db_rollback(); return -22; }
 
+  # Log server creation to history
+  my $server_name = $rec->{name} || '';
+  update_history($muid, $msid, 3, "ADD: Server", "name: $server_name", $id);
 
   return -100 if (db_commit() < 0);
   return $id;
@@ -1310,6 +1326,11 @@ sub delete_server($) {
 
   return -100 unless ($id > 0);
 
+  # Get server name for history log BEFORE deletion
+  my %server_data;
+  get_server($id, \%server_data);
+  my $server_name = $server_data{name} || "ID=$id";
+
   write2log("SERVER_DELETE_START: Deleting server ID=$id");
   db_begin();
 
@@ -1339,11 +1360,14 @@ sub delete_server($) {
     write2log("SERVER_DELETE_FAILED: Server ID=$id was NOT deleted - failure to delete server parts with error $res");
     return $res;
   }
+
   if (db_commit() < 0) {
     write2log("SERVER_DELETE_FAILED: Server ID=$id was NOT deleted - commit failure");
     return -200;
   }
 
+  # Log server deletion to history (after commit)
+  update_history($muid, $msid, 3, "DELETE: Server", "name: $server_name", $id);
   write2log("SERVER_DELETE_SUCCESS: Server ID=$id successfully deleted");
 
   return 0;
@@ -1837,6 +1861,10 @@ sub update_zone($) {
     }
   }
 
+  # Log zone update to history (before commit)
+  my $zone_name = $rec->{name} || "ID=$id";
+  update_history($muid, $msid, 2, "EDIT: Zone", "name: $zone_name", $id);
+
   return db_commit();
 }
 
@@ -1996,11 +2024,17 @@ sub delete_zone($) {
         return $res;
     }
 
+    # Log zone deletion to history (before commit, using stored zone name)
+    my %zone_data;
+    get_zone($id, \%zone_data);
+    my $zone_name = $zone_data{name} || "ID=$id";
+    
     if (db_commit() < 0) {
         write2log("ZONE_DELETE_FAILED: Zone ID=$id WAS NOT deleted - commit failure");
         return -200;
     }
 
+    update_history($muid, $msid, 2, "DELETE: Zone", "name: $zone_name", $id);
     write2log("ZONE_DELETE_SUCCESS: Zone ID=$id successfully deleted");
     return 0;
 }
@@ -2093,6 +2127,11 @@ sub add_zone($) {
   $res = add_array_field('txt_entries','txt,comment','zentries',$rec,
 			 'type,ref',"12,$id");
   if ($res < 0) { db_rollback(); return -8; }
+
+  # Log zone creation to history
+  my $zone_type = $rec->{type} || 'M';
+  my $zone_name = $rec->{name} || '';
+  update_history($muid, $msid, 2, "ADD: Zone type=$zone_type", "name: $zone_name", $id);
 
   return -100 if (db_commit() < 0);
   return $id;
@@ -4630,6 +4669,10 @@ sub update_history($$$$$$) {
   my($date,$a,$i,$sql);
 
 # uid and sid are -1 in some command line scripts
+# Use -1 as default if undefined
+  $uid = -1 unless (defined $uid);
+  $sid = -1 unless (defined $sid);
+  
   return -1 unless ($uid > 0 || $uid == -1);
   return -2 unless ($sid > 0 || $sid == -1);
   return -3 unless ($type > 0);
@@ -4731,6 +4774,38 @@ sub get_history_session($$)
   db_query("SELECT date,type,ref,action,info FROM history ".
 	   "WHERE sid=$id ORDER BY date ",$list);
 
+  return 0;
+}
+
+sub get_history_zone($$)
+{
+  my ($id,$list) = @_;
+  my (@q,%users,$i);
+
+  return -1 unless ($id > 0);
+  db_query("SELECT date,action,info,uid FROM history ".
+	   "WHERE type=2 AND ref=$id ORDER BY date ",$list);
+  db_query("SELECT id,username FROM users",\@q);
+  for $i (0..$#q) { $users{$q[$i][0]}=$q[$i][1]; }
+  for $i (0..$#{$list}) {
+    $$list[$i][3] = $users{$$list[$i][3]} if ($users{$$list[$i][3]});
+  }
+  return 0;
+}
+
+sub get_history_server($$)
+{
+  my ($id,$list) = @_;
+  my (@q,%users,$i);
+
+  return -1 unless ($id > 0);
+  db_query("SELECT date,action,info,uid FROM history ".
+	   "WHERE type=3 AND ref=$id ORDER BY date ",$list);
+  db_query("SELECT id,username FROM users",\@q);
+  for $i (0..$#q) { $users{$q[$i][0]}=$q[$i][1]; }
+  for $i (0..$#{$list}) {
+    $$list[$i][3] = $users{$$list[$i][3]} if ($users{$$list[$i][3]});
+  }
   return 0;
 }
 

--- a/Sauron/CGI/Servers.pm
+++ b/Sauron/CGI/Servers.pm
@@ -301,6 +301,15 @@ sub display_new_server($$$$)
     save_state($scookie,$state);
   }
 
+  # Display action bar with History button (similar to hosts/zones)
+  my $selfurl = $state->{selfurl};
+  print '<div class="s-action-bar"><div class="s-action-bar__right">',
+        start_form(-method=>'POST',-action=>$selfurl,-class=>'s-inline-form'),
+        hidden('menu','servers'),hidden('sub','History'),
+        submit(-name=>'sub',-value=>'History'), ' '
+          if (!check_perms('level',$main::ALEVEL_HISTORY,1));
+  print '</div></div>';
+
   display_form(\%serv,\%server_form); # display server record
   return 0;
 }
@@ -321,7 +330,8 @@ sub menu_handler {
 
   my($res,%data,%serv,%srec,@l,$server);
 
-  if ($serverid && check_perms('server','R')) {
+  # Do not redirect for History action
+  if ($serverid && check_perms('server','R') && $sub ne 'History') {
     select_server($state,$perms);
     return;
   }
@@ -380,8 +390,27 @@ sub menu_handler {
 
   $serverid=param('server_list') if (param('server_list'));
 
-  if ($serverid && $sub ne 'select') {
+  # Do not redirect for History action
+  if ($serverid && $sub ne 'select' && $sub ne 'History') {
     display_new_server($state,$perms,$serverid,$scookie);
+    return;
+  }
+
+  # Handle History sub-action
+  if ($sub eq 'History') {
+    return if (check_perms('level',$main::ALEVEL_HISTORY));
+    unless ($serverid > 0) {
+      select_server($state,$perms);
+      return;
+    }
+    my %server_data;
+    get_server($serverid,\%server_data);
+    my $server_name = $server_data{name} || '';
+    print "History for server record: $serverid ($server_name):<br>";
+    my @q;
+    get_history_server($serverid,\@q);
+    unshift @q, [$server_data{cdate},'CREATE','server created',$server_data{cuser}];
+    display_list(['Date','Action','Info','By'],\@q,0);
     return;
   }
 

--- a/Sauron/CGI/Servers.pm
+++ b/Sauron/CGI/Servers.pm
@@ -303,12 +303,14 @@ sub display_new_server($$$$)
 
   # Display action bar with History button (similar to hosts/zones)
   my $selfurl = $state->{selfurl};
-  print '<div class="s-action-bar"><div class="s-action-bar__right">',
-        start_form(-method=>'POST',-action=>$selfurl,-class=>'s-inline-form'),
-        hidden('menu','servers'),hidden('sub','History'),
-        submit(-name=>'sub',-value=>'History'), ' '
-          if (!check_perms('level',$main::ALEVEL_HISTORY,1));
-  print '</div></div>';
+  if (!check_perms('level',$main::ALEVEL_HISTORY,1)) {
+    print '<div class="s-action-bar"><div class="s-action-bar__right">',
+          start_form(-method=>'POST',-action=>$selfurl,-class=>'s-inline-form'),
+          hidden('menu','servers'),hidden('sub','History'),
+          submit(-name=>'sub',-value=>'History'),' ',
+          end_form,
+          '</div></div>';
+  }
 
   display_form(\%serv,\%server_form); # display server record
   return 0;

--- a/Sauron/CGI/Zones.pm
+++ b/Sauron/CGI/Zones.pm
@@ -496,12 +496,14 @@ sub display_zone($$)
     }
 
     # Display action bar with History button (similar to hosts)
-    print '<div class="s-action-bar"><div class="s-action-bar__right">',
-          start_form(-method=>'POST',-action=>$selfurl,-class=>'s-inline-form'),
-          hidden('menu','zones'),hidden('sub','History'),
-          submit(-name=>'sub',-value=>'History'), ' '
-            if (!check_perms('level',$main::ALEVEL_HISTORY,1));
-    print '</div></div>';
+    if (!check_perms('level',$main::ALEVEL_HISTORY,1)) {
+      print '<div class="s-action-bar"><div class="s-action-bar__right">',
+            start_form(-method=>'POST',-action=>$selfurl,-class=>'s-inline-form'),
+            hidden('menu','zones'),hidden('sub','History'),
+            submit(-name=>'sub',-value=>'History'),' ',
+            end_form,
+            '</div></div>';
+    }
 
     display_form(\%data,\%zone_form);
     return;

--- a/Sauron/CGI/Zones.pm
+++ b/Sauron/CGI/Zones.pm
@@ -495,6 +495,14 @@ sub display_zone($$)
       $data{catalog_zones_selected_links} = join(', ', sort @catalog_zone_links) if @catalog_zone_links;
     }
 
+    # Display action bar with History button (similar to hosts)
+    print '<div class="s-action-bar"><div class="s-action-bar__right">',
+          start_form(-method=>'POST',-action=>$selfurl,-class=>'s-inline-form'),
+          hidden('menu','zones'),hidden('sub','History'),
+          submit(-name=>'sub',-value=>'History'), ' '
+            if (!check_perms('level',$main::ALEVEL_HISTORY,1));
+    print '</div></div>';
+
     display_form(\%data,\%zone_form);
     return;
   }
@@ -898,6 +906,20 @@ sub menu_handler {
   }
   elsif ($sub eq 'Current') {
       param('selected_zone', $state->{'zone'}); # Show selected zone.
+  }
+  elsif ($sub eq 'History') {
+    return if (check_perms('level',$main::ALEVEL_HISTORY));
+    unless ($zoneid > 0) {
+      display_zone($state,$perms);
+      return;
+    }
+    my %zone_data;
+    get_zone($zoneid,\%zone_data);
+    my $zone_name = $zone_data{name} || $zone || '';
+    print "History for zone record: $zoneid ($zone_name):<br>";
+    get_history_zone($zoneid,\@q);
+    unshift @q, [$zone_data{cdate},'CREATE','zone created',$zone_data{cuser}];
+    display_list(['Date','Action','Info','By'],\@q,0);
   }
 
  display_zone($state,$perms);

--- a/cgi/sauron.cgi
+++ b/cgi/sauron.cgi
@@ -325,6 +325,7 @@ if ($pathinfo ne '') {
 cgi_util_set_zone($zoneid,$zone);
 cgi_util_set_server($serverid,$server);
 set_muser($state{user});
+set_muid_msid($state{uid}, $state{sid});
 
 unless (is_superuser()) {
   html_error("cannot get permissions!")
@@ -690,6 +691,7 @@ sub login_auth() {
 	$state{'uid'}=$user{'id'};
 	$state{'sid'}=new_sid();
 	$state{'login'}=$ticks;
+	set_muid_msid($state{'uid'}, $state{'sid'});
 	$state{'serverid'}=$user{'server'};
 	$state{'zoneid'}=$user{'zone'};
 	$state{'superuser'}='yes' if ($user{superuser} eq 't' ||
@@ -763,7 +765,7 @@ sub login_auth() {
 	print '</div></div></div>', "\n";
 	logmsg("notice","user ($u) logged in from: $remote_addr");
 	$last_from = db_encode_str($remote_addr);
-	db_exec("UPDATE users SET last=$ticks,last_from=$last_from " .
+    db_exec("UPDATE users SET last=$ticks,last_from=$last_from " .
 		"WHERE id=$user{'id'};");
 	update_lastlog($state{uid},$state{sid},1,
 		       $remote_addr,$remote_host);
@@ -783,7 +785,10 @@ sub login_auth() {
   print '</div></div></div>', "\n";
   print end_html();
   save_state($scookie,\%state);
-  load_state($scookie,\%state) if ($SAURON_AUTH_MODE==1);
+  if ($SAURON_AUTH_MODE==1) {
+      load_state($scookie,\%state);
+      set_muid_msid($state{uid}, $state{sid});
+  }
   fix_utmp($SAURON_USER_TIMEOUT*2, 0);
   exit;
 }


### PR DESCRIPTION
## Summary

This PR implements comprehensive history logging improvements for server and zone operations in Sauron. The changes ensure that all modifications to servers and zones are properly attributed to the user who made them, with detailed information about what specific changes were made.

## Changes

### Problem Fixed

Previously, history logging for server and zone operations used hardcoded `-1` values for user ID (UID) and session ID (SID), making it impossible to track which user made specific changes. The history info column only contained basic information like `name: zone_name` without details about what was actually changed.

### Solution

1. **Correct User Attribution** (`e188c6f`)
   - Added global variables `$muid` and `$msid` in BackEnd.pm for tracking user ID and session ID across function calls
   - Added `set_muid_msid()` function to set user ID and session ID globally
   - Fixed `update_history()` calls in server and zone operations to use actual user ID instead of `-1`
   - Moved `set_muid_msid()` call in sauron.cgi to after successful login

2. **Detailed Change Tracking** (`8d9d929`, `1a51285`, `df4e191`, `8ae85d9`)
   - Added `diff_records()` function to compare old and new record values
   - Added `extract_array_values()` helper function to properly handle multi-column fields
   - Modified `update_server()` and `update_zone()` to capture original records before modification
   - History now logs specific field changes with old and new values

### Files Modified

- `Sauron/BackEnd.pm` - Core backend functions with history logging improvements
- `Sauron/CGI/Servers.pm` - Server management CGI
- `Sauron/CGI/Zones.pm` - Zone management CGI  
- `cgi/sauron.cgi` - Main CGI script with login handling

### History Log Format Examples

**Before:**
```
name: acad.cz
```

**After:**
```
name: acad.cz | Changes: ns (ns1.example.com -> ns1.example.com,ns2.example.com), mx (10:mail1.example.com -> 10:mail1.example.com,20:mail2.example.com)
```

**For scalar fields:**
```
name: server1 | Changes: hostname ('old_host' -> 'new_host'), ttl ('3600' -> '7200')
```

**For array fields:**
```
name: example.com | Changes: ip (192.168.1.1,192.168.1.2 -> 192.168.1.1)
```

## Testing

History can be viewed via "History Search" in the Login menu (requires appropriate authorization level). Test by:
1. Editing a server or zone
2. Navigating to Login → History Search
3. Verifying the changes are logged with user attribution and detailed change information
