### PR TITLE
Add modern TSIG algorithm support (HMAC-SHA1/256/384/512)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,20 @@
 0.9.0 (beta)
 
+	- Add modern TSIG algorithm support (HMAC-SHA1/256/384/512) [svamberg]
+	  - keygen: generate keys with --algorithm (default HMAC-SHA256) and
+	    switch from dnssec-keygen to BIND's tsig-keygen, which is required
+	    for the HMAC family (path overridable via SAURON_TSIG_KEYGEN_PROG)
+	  - Store shared secrets in 8-byte RC5 blocks so the longer SHA secrets
+	    (20-64 bytes) are supported; existing HMAC-MD5 keys keep working
+	    byte-for-byte and require no migration (tsig_secret_encrypt/decrypt
+	    helpers in Sauron::Util)
+	  - setmasterkey re-encrypts secrets of any length and accepts the whole
+	    TSIG algorithm range (157-161)
+	  - sauron: emit the new algorithms in BIND configuration, trimming the
+	    decrypted secret back to its real length (keysize)
+	  - get_key_list() can match the whole TSIG family (algo == -1)
+	  - Unit tests for the encryption helpers (t/01-util.t)
+
 	- Add import-blocklist script for RPZ blocklist management [svamberg]
 	  - New Perl script for importing blocked domains from CSV files
 	  - Supports multiple sources with configurable column mapping

--- a/Sauron/BackEnd.pm
+++ b/Sauron/BackEnd.pm
@@ -4538,7 +4538,12 @@ sub get_key_list($$$$) {
   undef %{$rec};
   $$rec{-1}='--None--';
   return if ($serverid < 1);
-  $algorule=" AND algorithm=$algo " if ($algo > 0);
+  if ($algo > 0) {
+    $algorule=" AND algorithm=$algo ";
+  } elsif (defined($algo) && $algo == -1) {
+    # Whole TSIG family (HMAC-MD5/SHA1/SHA256/SHA384/SHA512).
+    $algorule=" AND algorithm >= 157 AND algorithm <= 161 ";
+  }
 
   db_query("SELECT id,name FROM keys " .
 	   "WHERE type=1 AND ref=$serverid $algorule ORDER BY name;",\@q);

--- a/Sauron/Util.pm
+++ b/Sauron/Util.pm
@@ -9,7 +9,6 @@ require Exporter;
 use Sauron::SetupIO;
 use Time::Local 'timelocal_nocheck';
 use Digest::MD5;
-use MIME::Base64;
 use Crypt::Cipher::RC5;
 # use Net::Netmask;
 use POSIX qw(strftime);

--- a/Sauron/Util.pm
+++ b/Sauron/Util.pm
@@ -9,6 +9,8 @@ require Exporter;
 use Sauron::SetupIO;
 use Time::Local 'timelocal_nocheck';
 use Digest::MD5;
+use MIME::Base64;
+use Crypt::Cipher::RC5;
 # use Net::Netmask;
 use POSIX qw(strftime);
 use Net::IP qw(:PROC);
@@ -83,6 +85,8 @@ $VERSION = '$Id:$ ';
          is_iaid
          trim
          dhcpduid
+	     tsig_secret_encrypt
+	     tsig_secret_decrypt
 	    );
 
 sub valid_base64($) {
@@ -1122,6 +1126,55 @@ sub trim($) {
     $s =~ s/\s+$//g;
 
     return $s;
+}
+
+
+#
+# TSIG shared secret encryption helpers.
+#
+# Sauron stores TSIG shared secrets in the database encrypted with the
+# Sauron master key using RC5.  The original code only handled a single
+# 8-byte (64-bit) block, which is enough for legacy HMAC-MD5 but not for
+# the modern HMAC-SHA* algorithms whose secrets are 20-64 bytes long.
+#
+# These helpers process the secret in 8-byte ECB blocks so secrets of any
+# length are supported.  For an 8-byte secret the output is byte-for-byte
+# identical to the old single-block code, so existing keys keep working.
+# The padding added to fill the last block is plain zero bytes; the real
+# secret length is tracked separately (the keysize column) and used to
+# trim the padding on decryption, so no ambiguous padding scheme is needed.
+#
+
+# tsig_secret_encrypt($masterkey, $secret)
+#   $masterkey - raw (binary) Sauron master key
+#   $secret    - raw (decoded) secret bytes
+# returns the raw (binary) ciphertext.
+sub tsig_secret_encrypt($$) {
+  my($masterkey,$secret) = @_;
+  my $cipher = Crypt::Cipher::RC5->new($masterkey,16);
+  # zero-pad to a full block boundary
+  $secret .= "\0" x ((8 - length($secret) % 8) % 8);
+  my $out = '';
+  for (my $i=0; $i < length($secret); $i += 8) {
+    $out .= $cipher->encrypt(substr($secret,$i,8));
+  }
+  return $out;
+}
+
+# tsig_secret_decrypt($masterkey, $crypted, $len)
+#   $masterkey - raw (binary) Sauron master key
+#   $crypted   - raw (binary) ciphertext
+#   $len       - real secret length in bytes (0 = keep full padded block(s))
+# returns the raw (binary) secret bytes.
+sub tsig_secret_decrypt($$$) {
+  my($masterkey,$crypted,$len) = @_;
+  my $cipher = Crypt::Cipher::RC5->new($masterkey,16);
+  my $out = '';
+  for (my $i=0; $i < length($crypted); $i += 8) {
+    $out .= $cipher->decrypt(substr($crypted,$i,8));
+  }
+  $out = substr($out,0,$len) if ($len > 0);
+  return $out;
 }
 
 

--- a/keygen
+++ b/keygen
@@ -13,24 +13,51 @@ use Sauron::Sauron;
 use Sauron::BackEnd;
 use Digest::MD5;
 use MIME::Base64;
-use Crypt::Cipher::RC5;
 use Sauron::SetupIO;
 use open ':locale';
 
-my %KEY_ALGORITHMS = ( 
+my %KEY_ALGORITHMS = (
 		       0=>'reserved',
 		       1=>'RSA/MD5',
 		       2=>'DH',
 		       3=>'DSA',
 		       4=>'ECC',
-		       157=>'HMAC-MD5'
+		       157=>'HMAC-MD5',
+		       158=>'HMAC-SHA1',
+		       159=>'HMAC-SHA256',
+		       160=>'HMAC-SHA384',
+		       161=>'HMAC-SHA512'
 		      );
+
+# Map Sauron algorithm id <-> tsig-keygen algorithm name (lower case).
+my %TSIG_ALG_NAME = (
+		       157=>'hmac-md5',
+		       158=>'hmac-sha1',
+		       159=>'hmac-sha256',
+		       160=>'hmac-sha384',
+		       161=>'hmac-sha512'
+		    );
+
+# Default TSIG algorithm used when --algorithm is not given.
+my $DEFAULT_TSIG_ALGORITHM = 'HMAC-SHA256';
 
 set_encoding();
 load_config();
 
 GetOptions("help|h","setmasterkey:s","add:s","del:s","regen:s","list:s",
-	   "verbose|v");
+	   "verbose|v","algorithm=s");
+
+# Resolve a TSIG algorithm name (any case, e.g. 'HMAC-SHA256') to its
+# Sauron algorithm id, or 0 if the name is not supported.
+sub tsig_algo_id($) {
+    my($name) = @_;
+    return 0 unless (defined $name && $name ne '');
+    $name =~ tr/A-Z/a-z/;
+    for my $id (keys %TSIG_ALG_NAME) {
+	return $id if ($TSIG_ALG_NAME{$id} eq $name);
+    }
+    return 0;
+}
 
 if ($opt_help || not (defined($opt_add) || defined $opt_del || 
 		   defined $opt_regen || defined $opt_list || 
@@ -48,8 +75,10 @@ if ($opt_help || not (defined($opt_add) || defined $opt_del ||
         "\t--regen=<server>,<keytype>\n",
         "\t--del=<server>,<keyname>\n",
         "\t--add=\"<server>,<keyname>,<keytype>,<keylen>[,<comments>,<passphrase>]\"\n",
+        "\t--algorithm=<alg>\tTSIG algorithm (default: $DEFAULT_TSIG_ALGORITHM)\n",
 	"\n\t--verbose\tverbose output\n",
-        "\n\nsupported key types: TSIG\n\n";
+        "\n\nsupported key types: TSIG\n",
+        "supported TSIG algorithms: HMAC-SHA256, HMAC-SHA384, HMAC-SHA512, HMAC-SHA1, HMAC-MD5\n\n";
   exit(0);
 }
 
@@ -138,50 +167,33 @@ sub make_tmpdir() {
 }
 
 
-sub generate_key($$$) {
-    my($name,$type,$len) = @_;
+sub generate_key($$$$) {
+    my($name,$type,$len,$algo) = @_;
     my $key;
 
-    fatal("SAURON_DNSSEC_KEYGEN_PROG configuration option not defined")
-	unless ($SAURON_DNSSEC_KEYGEN_PROG);
-    fatal("Cannot execute: $SAURON_DNSSEC_KEYGEN_PROG")
-	unless (-x $SAURON_DNSSEC_KEYGEN_PROG);
+    fatal("support this keytype not implemented yet: $type")
+	unless ($type eq 'TSIG');
 
-    my $opts = $SAURON_DNSSEC_KEYGEN_ARGS;
+    my $alg_name = $TSIG_ALG_NAME{$algo};
+    fatal("unsupported TSIG algorithm id: $algo") unless ($alg_name);
 
-    if ($type eq 'TSIG') {
-	$args = "-a HMAC-MD5 -b $len -n USER"; 
-    } else {
-	fatal("support this keytype not implemented yet: $type");
-    }
+    # Modern BIND ships tsig-keygen for generating TSIG shared secrets;
+    # dnssec-keygen no longer supports the HMAC algorithms.  The program
+    # path can be overridden with the SAURON_TSIG_KEYGEN_PROG config option.
+    my $tsig_prog = ($SAURON_TSIG_KEYGEN_PROG || '/usr/sbin/tsig-keygen');
+    fatal("Cannot execute tsig-keygen: $tsig_prog")
+	unless (-x $tsig_prog);
 
-    my $tmpdir=make_tmpdir();
-    chdir($tmpdir) || fatal("cannot access tmp dir: $tmpdir");
-
-    my $keyid = '';
-    open(PIPE,"$SAURON_DNSSEC_KEYGEN_PROG $args $opts keygen |") ||
-	fatal("pipe failed");
+    # Use the list form of open() so the key name cannot be interpreted by
+    # a shell (it is already validated by valid_texthandle(), but be safe).
+    open(PIPE,"-|",$tsig_prog,"-a",$alg_name,$name) ||
+	fatal("failed to run $tsig_prog");
     while(<PIPE>) {
 	chomp;
-        $keyid=$1 if (/^(Kkeygen\S+)\s*$/);
+	$key = $1 if (/secret\s+"([^"]+)"/);
     }
     close(PIPE);
-    fatal("failed to generate key!") unless ($keyid);
-
-    my $keyfile = $tmpdir."/".$keyid.".key";
-    my $keyfile2 = $tmpdir."/".$keyid.".private";
-
-    open(FILE,$keyfile) || fatal("failed to open: $keyfile");
-    while(<FILE>) {
-	chomp;
-	$key = $1 if (/^\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)/);
-    }
-    close(FILE);
-
-
-    unlink($keyfile) || error("failed to remove: $keyfile");
-    unlink($keyfile2) || error("failed to remove: $keyfile2");
-    rmdir($tmpdir) || error("failed to remove: $tmpdir");
+    fatal("failed to generate key!") unless ($key);
 
     return $key;
 }
@@ -242,13 +254,15 @@ sub setmasterkey($) {
 	for $i (0..$#keys) {
 	    my $name = $keys[$i][2];
 	    my $algo = $keys[$i][3];
-	    fatal("unsupported key: $name (algorithm=$algo)") 
-	      if ($algo != 157);
+	    # All TSIG family algorithms (HMAC-MD5/SHA1/SHA256/SHA384/SHA512).
+	    fatal("unsupported key: $name (algorithm=$algo)")
+	      if ($algo < 157 || $algo > 161);
 	    if ($keys[$i][1]) {
-		my $ref1 = Crypt::Cipher::RC5->new($oldkey,16);
-		my $okey=$ref1->decrypt(decode_base64($keys[$i][1]));
-		my $ref2 = Crypt::Cipher::RC5->new($key,16);
-		my $nkey=encode_base64($ref2->encrypt($okey));
+		# Re-encrypt the stored (padded) ciphertext blocks: decrypt
+		# with the old master key, encrypt with the new one.  Length 0
+		# keeps the padding intact so the round-trip is exact.
+		my $okey=tsig_secret_decrypt($oldkey,decode_base64($keys[$i][1]),0);
+		my $nkey=encode_base64(tsig_secret_encrypt($key,$okey),"");
 		chomp($nkey);
 		if (db_exec("UPDATE keys SET secretkey='$nkey' " .
 			    "WHERE id=$keys[$i][0]\n") < 0) {
@@ -291,21 +305,33 @@ sub addkey() {
 
     $type=gettype($type);
     if ($type eq  'TSIG') {
-	$len=getlen($len,1,512,128);
-	$algo=157;
+	my $alg = ($opt_algorithm || $DEFAULT_TSIG_ALGORITHM);
+	$algo = tsig_algo_id($alg);
+	fatal("unsupported TSIG algorithm: $alg\n" .
+	      "supported: HMAC-SHA256, HMAC-SHA384, HMAC-SHA512, HMAC-SHA1, HMAC-MD5")
+	    unless ($algo);
     } else {
 	fatal("unsupported key type");
     }
-    
+
     if ($key) {
+	# Static key: the secret is supplied (Base64) by the user.  Store it
+	# encrypted just like a generated key so it decrypts correctly when
+	# the server configuration is generated.
 	fatal("Key must be in Base64 (MIME) format")
 	    unless ($key =~ /^[a-zA-Z0-9+\/=]+$/);
+	my $raw = decode_base64($key);
+	$len = length($raw) * 8;
+	$key = encode_base64(tsig_secret_encrypt($SAURON_KEY,$raw),"");
 	$mode=1;
     } else {
 	print "Generating key...\n";
-	my $okey = generate_key($name,$type,$len);
-	my $ref = Crypt::Cipher::RC5->new($SAURON_KEY,16);
-	$key=encode_base64($ref->encrypt(decode_base64($okey)));
+	my $okey = generate_key($name,$type,$len,$algo);
+	my $raw = decode_base64($okey);
+	# tsig-keygen determines the secret length from the algorithm; record
+	# the actual length (in bits) so it can be trimmed back on decryption.
+	$len = length($raw) * 8;
+	$key = encode_base64(tsig_secret_encrypt($SAURON_KEY,$raw),"");
 	print "Key: $okey  Encrypted-Key: $key\n" if ($opt_verbose);
 	$mode=0;
     }
@@ -383,14 +409,15 @@ sub regenkeys($) {
     my($id,$name,$algo,$len) = @{$keys[$i]};
 
     print "Generating key: $name ...\n";
-    my $okey = generate_key($name,$type,$len);
-    my $ref = Crypt::Cipher::RC5->new($SAURON_KEY,16);
-    my $key=encode_base64($ref->encrypt(decode_base64($okey)));
+    my $okey = generate_key($name,$type,$len,$algo);
+    my $raw = decode_base64($okey);
+    my $newlen = length($raw) * 8;
+    my $key=encode_base64(tsig_secret_encrypt($SAURON_KEY,$raw),"");
     chomp($key);
     print "Key: $okey  Encrypted-Key: $key\n" if ($opt_verbose);
-    
+
     fatal("Failed to update key: $name")
-      if (update_key({id=>$id,secretkey=>$key}) < 0);
+      if (update_key({id=>$id,secretkey=>$key,keysize=>$newlen}) < 0);
   }
 
 }

--- a/keygen
+++ b/keygen
@@ -186,7 +186,7 @@ sub generate_key($$$$) {
 
     # Use the list form of open() so the key name cannot be interpreted by
     # a shell (it is already validated by valid_texthandle(), but be safe).
-    open(PIPE,"-|",$tsig_prog,"-a",$alg_name,$name) ||
+    open(PIPE,"-|",$tsig_prog,"-a",$alg_name,"--",$name) ||
 	fatal("failed to run $tsig_prog");
     while(<PIPE>) {
 	chomp;

--- a/sauron
+++ b/sauron
@@ -11,7 +11,6 @@ require 5;
 use NetAddr::IP; # For IPv6.
 use Getopt::Long;
 use MIME::Base64;
-use Crypt::Cipher::RC5;
 use Sauron::Util;
 use Sauron::DB;
 use Sauron::BackEnd;
@@ -34,7 +33,11 @@ $printer_conf=0;
 # Catalog zones (C) and aggregate catalog zones (A) are configured as type master in BIND (RFC 9432)
 %zone_type_enum = (M=>'master',S=>'slave',H=>'hint',F=>'forward',C=>'master',A=>'master');
 %forward_enum = (D=>'', O=>'only', F=>'first');
-%algorithm_enum = (157=>'hmac-md5');
+%algorithm_enum = (157=>'hmac-md5',
+		   158=>'hmac-sha1',
+		   159=>'hmac-sha256',
+		   160=>'hmac-sha384',
+		   161=>'hmac-sha512');
 
 $ZFORMAT = "%-22s %6s %2s  %-6s %s\n";
 
@@ -3448,6 +3451,7 @@ sub print_keys_acls($) {
               my $name = $keys[$i][1];
               my $algorithm = $algorithm_enum{$keys[$i][2]};
               my $key = $keys[$i][5];
+              my $keysize = $keys[$i][4];
               my $comment = $keys[$i][6];
 
               unless ($name) {
@@ -3463,8 +3467,11 @@ sub print_keys_acls($) {
                   error("Skipping key with empty secret key: $name");
                   next;
               }
-              my $h = Crypt::Cipher::RC5->new($SAURON_KEY,16);
-              my $dkey = encode_base64($h->decrypt(decode_base64($key)));
+              # Decrypt the shared secret and trim the block padding back to
+              # the real secret length (keysize is stored in bits).
+              my $dkey = encode_base64(
+                  tsig_secret_decrypt($SAURON_KEY,decode_base64($key),
+                                      int($keysize/8)),"");
               chomp($dkey);
 
               $comment =~ s/(^\s+|\s+$)//g;

--- a/t/01-util.t
+++ b/t/01-util.t
@@ -298,4 +298,40 @@ subtest 'new_serial' => sub {
     like($s, qr/^\d{10}$/, 'serial has 10 digits');
 };
 
+# =========================================================================
+# tsig_secret_encrypt / tsig_secret_decrypt
+# =========================================================================
+subtest 'tsig_secret_encrypt/decrypt round-trip' => sub {
+    my $masterkey = "0123456789abcdef";  # 16-byte raw master key
+
+    # Secret lengths used by the TSIG HMAC family:
+    #   MD5=16, SHA1=20, SHA256=32, SHA384=48, SHA512=64 bytes,
+    #   plus an exact single block (8) and a non-block-multiple (10).
+    for my $len (8, 10, 16, 20, 32, 48, 64) {
+        my $secret = join('', map { chr($_ % 256) } 1..$len);
+        my $enc = tsig_secret_encrypt($masterkey, $secret);
+        is(length($enc) % 8, 0, "len=$len: ciphertext is block-aligned");
+        my $dec = tsig_secret_decrypt($masterkey, $enc, $len);
+        is($dec, $secret, "len=$len: round-trip restores secret exactly");
+    }
+};
+
+subtest 'tsig_secret backward compatibility (single block)' => sub {
+    # An 8-byte secret must encrypt to a single RC5 block identical to the
+    # old single-block code, so existing HMAC-MD5 keys keep decrypting.
+    require Crypt::Cipher::RC5;
+    my $masterkey = "0123456789abcdef";
+    my $secret    = "12345678";  # exactly one 8-byte block
+
+    my $old = Crypt::Cipher::RC5->new($masterkey, 16)->encrypt($secret);
+    my $new = tsig_secret_encrypt($masterkey, $secret);
+    is($new, $old, 'single-block ciphertext matches legacy RC5 output');
+
+    # Decrypting with len=0 keeps the full (unpadded) block.
+    is(tsig_secret_decrypt($masterkey, $new, 0), $secret,
+       'len=0 keeps full single block');
+    is(tsig_secret_decrypt($masterkey, $new, 8), $secret,
+       'len=8 returns exact secret');
+};
+
 done_testing();


### PR DESCRIPTION
Sauron previously supported only HMAC-MD5 for TSIG keys. This adds the full modern HMAC family and switches key generation to BIND's tsig-keygen, since dnssec-keygen no longer generates HMAC secrets.

The longer SHA secrets (20-64 bytes) exposed a limitation in the old key storage code, which only encrypted a single 8-byte RC5 block. Encryption is now block-aware while staying byte-for-byte compatible with existing HMAC-MD5 keys, so no migration is required.

Sauron/Util.pm:
- Add `tsig_secret_encrypt()`/`tsig_secret_decrypt()` helpers that process the shared secret in 8-byte RC5 ECB blocks. Secrets are zero-padded to a block boundary; the real length (keysize column) is used to trim the padding on decryption. An 8-byte secret produces identical output to the previous single-block code.

keygen:
- Register algorithm ids 158-161 (HMAC-SHA1/256/384/512) and map them to tsig-keygen algorithm names.
- Add `--algorithm` option (default HMAC-SHA256) and update usage text.
- Replace `dnssec-keygen` invocation with `tsig-keygen` (path overridable via SAURON_TSIG_KEYGEN_PROG), parsing the secret directly from its output and dropping the temp-file handling. Use list-form `open()` to avoid the shell.
- Encrypt generated/static secrets via the new helpers and record the actual key length; setmasterkey now re-encrypts the whole padded ciphertext and accepts the full TSIG algorithm range (157-161).

sauron:
- Extend `%algorithm_enum` with the SHA algorithms.
- Decrypt shared secrets via `tsig_secret_decrypt()`, trimming padding back to keysize when emitting BIND configuration.

Sauron/BackEnd.pm:
- `get_key_list()` accepts `algo == -1` to match the whole TSIG family.

t/01-util.t:
- Add round-trip tests for the new helpers across MD5..SHA512 secret lengths and a backward-compatibility test asserting single-block output matches the legacy RC5 encoding.