### PR TITLE
Fix UTF-8 mojibake in CGI edit/save flow (real root cause)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -33,7 +33,31 @@
 	    used with --commit (still non-destructive without --commit)
 	  - Added upgrade notes for one-time repair of already corrupted records
 	    (README.upgrade)
-	- Added KEA DHCP configuration import support: parses KEA JSON 
+	- Reworked UTF-8 handling into a clean single decode/encode boundary
+	  model, superseding the earlier mojibake-repair heuristic [svamberg]
+	  - Root cause: with this CGI.pm + module stack, request parameters
+	    arrive as the raw UTF-8 octets reinterpreted as Latin-1 codepoints,
+	    with the UTF8 flag already set -- e.g. "ž" (octets C5 BE) becomes the
+	    codepoints U+00C5 U+00BE ("Å¾"). Sent to DBD::Pg/db_encode_str it is
+	    re-encoded to UTF-8, double-encoding the value on every save
+	    (e.g. "žluťoučký" -> "Å¾luÅ¥ouÄ\x8dký", getting worse with each
+	    edit, including via form-reloading "Add" buttons)
+	  - The previous fix_param_utf8() heuristic only repaired this inside
+	    form_check_form(), so any path that bypassed it (form-reloading
+	    buttons, sticky form re-render) still corrupted the text. Removed.
+	  - decode_cgi_params() (Sauron::CGIutil) now repairs every request
+	    parameter once at the boundary: map the codepoints back to octets
+	    (encode ISO-8859-1) and decode them as UTF-8. FB_CROAK makes it
+	    self-guarding -- already-correct wide text and non-UTF-8 values are
+	    left untouched, so it is idempotent across repeated round trips.
+	    The unreliable -utf8 / $CGI::PARAM_UTF8 path was dropped.
+	  - Data is then kept as Perl wide-character strings end to end: DBD::Pg
+	    pg_enable_utf8 decodes DB reads, and the response body is encoded
+	    exactly once via an explicit STDOUT binmode driven by the configured
+	    web charset (independent of the server locale)
+	  - Added regression tests including the UTF8-flagged mojibake case, the
+	    write-path invariant and round-trip stability (t/07-utf8-encoding.t)
+	- Added KEA DHCP configuration import support: parses KEA JSON
 	  configs (DHCPv4/DHCPv6) and converts subnets, pools, reservations, 
 	  shared-networks and options to ISC-like internal format used 
 	  by import-dhcp [svamberg]

--- a/Sauron/CGI/ACLs.pm
+++ b/Sauron/CGI/ACLs.pm
@@ -6,7 +6,7 @@
 #
 package Sauron::CGI::ACLs;
 require Exporter;
-use CGI qw/:standard *table -utf8/;
+use CGI qw/:standard *table/;
 use Sauron::DB;
 use Sauron::CGIutil;
 use Sauron::BackEnd;

--- a/Sauron/CGI/Approvals.pm
+++ b/Sauron/CGI/Approvals.pm
@@ -2,7 +2,7 @@
 #
 package Sauron::CGI::Approvals;
 require Exporter;
-use CGI qw/:standard *table -utf8/;
+use CGI qw/:standard *table/;
 use Sauron::DB;
 use Sauron::CGIutil;
 use Sauron::BackEnd;

--- a/Sauron/CGI/Groups.pm
+++ b/Sauron/CGI/Groups.pm
@@ -6,7 +6,7 @@
 #
 package Sauron::CGI::Groups;
 require Exporter;
-use CGI qw/:standard *table -utf8/;
+use CGI qw/:standard *table/;
 use Sauron::DB;
 use Sauron::CGIutil;
 use Sauron::BackEnd;

--- a/Sauron/CGI/Hosts.pm
+++ b/Sauron/CGI/Hosts.pm
@@ -6,7 +6,7 @@
 #
 package Sauron::CGI::Hosts;
 require Exporter;
-use CGI qw/:standard *table -utf8/;
+use CGI qw/:standard *table/;
 #use CGI qw/:cgi/; # enable when debugging with url()
 use Sauron::DB;
 use Sauron::CGIutil;

--- a/Sauron/CGI/Login.pm
+++ b/Sauron/CGI/Login.pm
@@ -5,7 +5,7 @@
 #
 package Sauron::CGI::Login;
 require Exporter;
-use CGI qw/:standard *table -utf8/;
+use CGI qw/:standard *table/;
 use HTML::Entities;
 use Sauron::DB;
 use Sauron::Util;

--- a/Sauron/CGI/Nets.pm
+++ b/Sauron/CGI/Nets.pm
@@ -6,7 +6,7 @@
 #
 package Sauron::CGI::Nets;
 require Exporter;
-use CGI qw/:standard *table -utf8/;
+use CGI qw/:standard *table/;
 use HTML::Entities;
 use Sauron::Util;
 use Sauron::DB;

--- a/Sauron/CGI/Servers.pm
+++ b/Sauron/CGI/Servers.pm
@@ -6,7 +6,7 @@
 #
 package Sauron::CGI::Servers;
 require Exporter;
-use CGI qw/:standard *table -utf8/;
+use CGI qw/:standard *table/;
 use Sauron::CGIutil;
 use Sauron::BackEnd;
 use Sauron::Sauron;

--- a/Sauron/CGI/Templates.pm
+++ b/Sauron/CGI/Templates.pm
@@ -5,7 +5,7 @@
 #
 package Sauron::CGI::Templates;
 require Exporter;
-use CGI qw/:standard *table -utf8/;
+use CGI qw/:standard *table/;
 use Sauron::DB;
 use Sauron::CGIutil;
 use Sauron::BackEnd;

--- a/Sauron/CGI/Utils.pm
+++ b/Sauron/CGI/Utils.pm
@@ -6,7 +6,7 @@
 #
 package Sauron::CGI::Utils;
 require Exporter;
-use CGI qw/:standard *table -utf8/;
+use CGI qw/:standard *table/;
 use Digest::MD5;
 use Sauron::CGIutil;
 use Sauron::BackEnd;

--- a/Sauron/CGI/Zones.pm
+++ b/Sauron/CGI/Zones.pm
@@ -6,7 +6,7 @@
 #
 package Sauron::CGI::Zones;
 require Exporter;
-use CGI qw/:standard *table -utf8/;
+use CGI qw/:standard *table/;
 use Sauron::DB;
 use Sauron::CGIutil;
 use Sauron::BackEnd;

--- a/Sauron/CGIutil.pm
+++ b/Sauron/CGIutil.pm
@@ -13,7 +13,7 @@ use Sauron::Util;
 use Sauron::BackEnd;
 use Net::IP qw(:PROC);
 use HTML::Entities;
-use Encode qw(encode decode FB_CROAK);
+use Encode qw(decode encode FB_CROAK);
 # use Data::Dumper;
 
 use strict;
@@ -23,6 +23,8 @@ $VERSION = '$Id:$ ';
 
 @ISA = qw(Exporter); # Inherit from Exporter
 @EXPORT = qw(
+	     decode_cgi_params
+
 	     cgi_util_set_zone
 	     cgi_util_set_server
 	     valid_safe_string
@@ -44,6 +46,57 @@ $VERSION = '$Id:$ ';
 	     html_error2
 	    );
 
+
+# Normalize all incoming CGI parameters to proper Perl wide-character strings,
+# exactly once, at the request boundary.
+#
+# In this CGI.pm + module stack, request parameters arrive as the raw UTF-8
+# octets reinterpreted as individual Latin-1 codepoints -- e.g. "ž" (U+017E,
+# octets C5 BE) comes in as the two codepoints U+00C5 U+00BE ("Å¾") -- and the
+# UTF8 flag may even be set on that mis-decoded string. Neither -utf8 /
+# $CGI::PARAM_UTF8 nor a flag check fixes this; the old fix_param_utf8()
+# heuristic was silently repairing it, but only inside form_check_form(), so
+# any path that bypassed it (form-reloading "Add" buttons, sticky re-render)
+# still corrupted the text and every round trip added another layer.
+#
+# We repair it centrally here so every downstream consumer -- sticky form
+# re-render via param(), form_check_form(), and DB writes via db_encode_str() --
+# sees consistent wide-char text, which is then encoded exactly once by the
+# output binmode and by DBD::Pg on the DB write.
+#
+# Repair = map the codepoints back to octets (encode as ISO-8859-1) and decode
+# them as UTF-8. FB_CROAK makes this self-guarding: it leaves untouched any
+# value that is already proper wide text (a codepoint > 255 cannot be an
+# ISO-8859-1 octet) or that is not valid UTF-8 when reinterpreted. Only relevant
+# for UTF-8 deployments; legacy byte-oriented charsets are left alone.
+#
+# This is the single authority for input decoding. CGI.pm's own -utf8 /
+# $CGI::PARAM_UTF8 mechanism is intentionally not relied upon anywhere (it is not
+# imported), so the repair must be -- and is -- agnostic to whether a value
+# arrives flagged or not.
+sub decode_cgi_params(;$) {
+  my ($charset) = @_;
+  $charset = 'UTF-8' unless (defined $charset && $charset ne '');
+  return unless ($charset =~ /utf-?8/i);
+
+  my $have_multi = CGI->can('multi_param');
+  foreach my $name (param()) {     # no-arg param() lists names (no warning)
+    # multi_param() is the sanctioned way to read all values of a parameter
+    # without triggering CGI.pm's list-context security warning.
+    my @vals = $have_multi ? multi_param($name) : param($name);
+    my $changed = 0;
+    foreach my $v (@vals) {
+      next unless (defined $v && $v ne '');
+      # local $@ so the repair's control-flow eval never clobbers the caller's $@
+      my $fixed = do {
+        local $@;
+        eval { decode('UTF-8', encode('ISO-8859-1', $v, FB_CROAK), FB_CROAK) };
+      };
+      if (defined $fixed && $fixed ne $v) { $v = $fixed; $changed = 1; }
+    }
+    param($name, @vals) if $changed;
+  }
+}
 
 my($CGI_UTIL_zoneid,$CGI_UTIL_zone);
 my($CGI_UTIL_serverid,$CGI_UTIL_server);
@@ -404,24 +457,6 @@ sub remove_whitespace($$) {
     return $val;
 }
 
-# Repair typical UTF-8 mojibake caused by ISO-8859-1 decoding in CGI layer.
-# If conversion is not safe/applicable, keep original value unchanged.
-sub fix_param_utf8($) {
-  my ($val) = @_;
-
-  return $val unless defined $val;
-  return $val if $val eq '';
-  return $val unless ((($main::SAURON_CHARSET // '') =~ /utf-?8/i) ||
-                      (($main::BROWSER_CHARSET // '') =~ /utf-?8/i));
-
-  my $fixed = eval {
-    my $octets = encode('ISO-8859-1', $val, FB_CROAK);
-    decode('UTF-8', $octets, FB_CROAK);
-  };
-
-  return defined $fixed ? $fixed : $val;
-}
-
 #####################################################################
 # form_check_form($prefix,$data,$form)
 #
@@ -489,7 +524,7 @@ sub form_check_form($$$) {
       next unless ($val =~ /^($e)$/);
     }
 
-    $val=fix_param_utf8(param($p));
+    $val=param($p);
     $val="\L$val" if ($rec->{conv} eq 'L');
     $val="\U$val" if ($rec->{conv} eq 'U');
 
@@ -569,8 +604,8 @@ sub form_check_form($$$) {
       $data->{$tag}=$val;
     }
     elsif ($type == 101) {
-      $tmp=fix_param_utf8(param($p));
-      $tmp=fix_param_utf8(param($p."_l")) if ($tmp eq '');
+      $tmp=param($p);
+      $tmp=param($p."_l") if ($tmp eq '');
       return 101 if (form_check_field($rec,$tmp,0) ne '');
       $data->{$tag}=$tmp;
     }
@@ -593,11 +628,11 @@ sub form_check_form($$$) {
 # Remove unnecessary whitespace from indexed input fields.
 # **	  if ($rec->{rows}
 	  param($p."_".$j."_".$k,
-	        remove_whitespace(fix_param_utf8(param($p."_".$j."_".$k)),
+	        remove_whitespace(param($p."_".$j."_".$k),
 				  $rec->{'whitesp'}[$k-1] || ''));
-          $tmp=fix_param_utf8(param($p."_".$j."_".$k));
+          $tmp=param($p."_".$j."_".$k);
           if ($rec->{type}[$k-1] eq 'enum') {
-            $tmp=fix_param_utf8(param($p."_".$j."_".$k."_enum")) if ($tmp eq '');
+            $tmp=param($p."_".$j."_".$k."_enum") if ($tmp eq '');
           }
 	  return 2
 	    if (form_check_field($rec,$tmp,$k) ne '');
@@ -628,9 +663,9 @@ sub form_check_form($$$) {
 	    $new=[];
 	    $$new[$f+1]=2;
 	    for $k (1..$f) {
-	      $tmp=fix_param_utf8(param($p2."_".$k));
+	      $tmp=param($p2."_".$k);
               if ($rec->{type}[$k-1] eq 'enum') {
-                $tmp=fix_param_utf8(param($p2."_".$k."_enum")) if ($tmp eq '');
+                $tmp=param($p2."_".$k."_enum") if ($tmp eq '');
               }
 	      $tmp=($tmp eq 'on' ? 't':'f') if ($type==5 && $k>1);
 	      $$new[$k]=$tmp;
@@ -640,9 +675,9 @@ sub form_check_form($$$) {
 	    for $k (1..$f) {
 	      if (param($p2."_".$k) ne $$list[$ind][$k]) {
 		$$list[$ind][$f+1]=1;
-		$tmp=fix_param_utf8(param($p2."_".$k));
+		$tmp=param($p2."_".$k);
                 if ($rec->{type}[$k-1] eq 'enum') {
-                  $tmp=fix_param_utf8(param($p2."_".$k."_enum")) if ($tmp eq '');
+                  $tmp=param($p2."_".$k."_enum") if ($tmp eq '');
                 }
 		$tmp=($tmp eq 'on' ? 't':'f') if ($type==5 && $k>1);
 		$$list[$ind][$k]=$tmp;
@@ -667,7 +702,7 @@ sub form_check_form($$$) {
       }
     }
     elsif ($type == 6 || $type == 7 || $type == 10) {
-      my $val = fix_param_utf8(param($p));
+      my $val = param($p);
       # Allow empty value if field has empty=>1
       if ($val eq '' && $rec->{empty}) {
         $data->{$tag} = -1;  # Set to -1 for empty optional groups
@@ -679,8 +714,7 @@ sub form_check_form($$$) {
     }
     elsif ($type == 13) { # Textarea (check input) 12 Apr 2017 TVu
 # Some sources say that line breaks in textarea depend on the client.
-  $val = fix_param_utf8($val);
-  $val =~ s/\r(?=\n)//gms; # cr/nl => nl (for Windows client)
+	$val =~ s/\r(?=\n)//gms; # cr/nl => nl (for Windows client)
 	$val =~ s/\r/\n/gms; # cr => nl (for Mac client)
 	my @val_arr = split(/\n/, $val);
 	my @val_arr2;

--- a/Sauron/CGIutil.pm
+++ b/Sauron/CGIutil.pm
@@ -13,7 +13,7 @@ use Sauron::Util;
 use Sauron::BackEnd;
 use Net::IP qw(:PROC);
 use HTML::Entities;
-use Encode qw(encode decode FB_CROAK);
+use Encode qw(decode encode FB_CROAK);
 # use Data::Dumper;
 
 use strict;
@@ -23,6 +23,8 @@ $VERSION = '$Id:$ ';
 
 @ISA = qw(Exporter); # Inherit from Exporter
 @EXPORT = qw(
+	     decode_cgi_params
+
 	     cgi_util_set_zone
 	     cgi_util_set_server
 	     valid_safe_string
@@ -44,6 +46,50 @@ $VERSION = '$Id:$ ';
 	     html_error2
 	    );
 
+
+# Normalize all incoming CGI parameters to proper Perl wide-character strings,
+# exactly once, at the request boundary.
+#
+# In this CGI.pm + module stack, request parameters arrive as the raw UTF-8
+# octets reinterpreted as individual Latin-1 codepoints -- e.g. "ž" (U+017E,
+# octets C5 BE) comes in as the two codepoints U+00C5 U+00BE ("Å¾") -- and the
+# UTF8 flag may even be set on that mis-decoded string. Neither -utf8 /
+# $CGI::PARAM_UTF8 nor a flag check fixes this; the old fix_param_utf8()
+# heuristic was silently repairing it, but only inside form_check_form(), so
+# any path that bypassed it (form-reloading "Add" buttons, sticky re-render)
+# still corrupted the text and every round trip added another layer.
+#
+# We repair it centrally here so every downstream consumer -- sticky form
+# re-render via param(), form_check_form(), and DB writes via db_encode_str() --
+# sees consistent wide-char text, which is then encoded exactly once by the
+# output binmode and by DBD::Pg on the DB write.
+#
+# Repair = map the codepoints back to octets (encode as ISO-8859-1) and decode
+# them as UTF-8. FB_CROAK makes this self-guarding: it leaves untouched any
+# value that is already proper wide text (a codepoint > 255 cannot be an
+# ISO-8859-1 octet) or that is not valid UTF-8 when reinterpreted. Only relevant
+# for UTF-8 deployments; legacy byte-oriented charsets are left alone.
+sub decode_cgi_params(;$) {
+  my ($charset) = @_;
+  $charset = 'UTF-8' unless (defined $charset && $charset ne '');
+  return unless ($charset =~ /utf-?8/i);
+
+  my $have_multi = CGI->can('multi_param');
+  foreach my $name (param()) {     # no-arg param() lists names (no warning)
+    # multi_param() is the sanctioned way to read all values of a parameter
+    # without triggering CGI.pm's list-context security warning.
+    my @vals = $have_multi ? multi_param($name) : param($name);
+    my $changed = 0;
+    foreach my $v (@vals) {
+      next unless (defined $v && $v ne '');
+      my $fixed = eval {
+        decode('UTF-8', encode('ISO-8859-1', $v, FB_CROAK), FB_CROAK);
+      };
+      if (defined $fixed && $fixed ne $v) { $v = $fixed; $changed = 1; }
+    }
+    param($name, @vals) if $changed;
+  }
+}
 
 my($CGI_UTIL_zoneid,$CGI_UTIL_zone);
 my($CGI_UTIL_serverid,$CGI_UTIL_server);
@@ -404,24 +450,6 @@ sub remove_whitespace($$) {
     return $val;
 }
 
-# Repair typical UTF-8 mojibake caused by ISO-8859-1 decoding in CGI layer.
-# If conversion is not safe/applicable, keep original value unchanged.
-sub fix_param_utf8($) {
-  my ($val) = @_;
-
-  return $val unless defined $val;
-  return $val if $val eq '';
-  return $val unless ((($main::SAURON_CHARSET // '') =~ /utf-?8/i) ||
-                      (($main::BROWSER_CHARSET // '') =~ /utf-?8/i));
-
-  my $fixed = eval {
-    my $octets = encode('ISO-8859-1', $val, FB_CROAK);
-    decode('UTF-8', $octets, FB_CROAK);
-  };
-
-  return defined $fixed ? $fixed : $val;
-}
-
 #####################################################################
 # form_check_form($prefix,$data,$form)
 #
@@ -489,7 +517,7 @@ sub form_check_form($$$) {
       next unless ($val =~ /^($e)$/);
     }
 
-    $val=fix_param_utf8(param($p));
+    $val=param($p);
     $val="\L$val" if ($rec->{conv} eq 'L');
     $val="\U$val" if ($rec->{conv} eq 'U');
 
@@ -569,8 +597,8 @@ sub form_check_form($$$) {
       $data->{$tag}=$val;
     }
     elsif ($type == 101) {
-      $tmp=fix_param_utf8(param($p));
-      $tmp=fix_param_utf8(param($p."_l")) if ($tmp eq '');
+      $tmp=param($p);
+      $tmp=param($p."_l") if ($tmp eq '');
       return 101 if (form_check_field($rec,$tmp,0) ne '');
       $data->{$tag}=$tmp;
     }
@@ -593,11 +621,11 @@ sub form_check_form($$$) {
 # Remove unnecessary whitespace from indexed input fields.
 # **	  if ($rec->{rows}
 	  param($p."_".$j."_".$k,
-	        remove_whitespace(fix_param_utf8(param($p."_".$j."_".$k)),
+	        remove_whitespace(param($p."_".$j."_".$k),
 				  $rec->{'whitesp'}[$k-1] || ''));
-          $tmp=fix_param_utf8(param($p."_".$j."_".$k));
+          $tmp=param($p."_".$j."_".$k);
           if ($rec->{type}[$k-1] eq 'enum') {
-            $tmp=fix_param_utf8(param($p."_".$j."_".$k."_enum")) if ($tmp eq '');
+            $tmp=param($p."_".$j."_".$k."_enum") if ($tmp eq '');
           }
 	  return 2
 	    if (form_check_field($rec,$tmp,$k) ne '');
@@ -628,9 +656,9 @@ sub form_check_form($$$) {
 	    $new=[];
 	    $$new[$f+1]=2;
 	    for $k (1..$f) {
-	      $tmp=fix_param_utf8(param($p2."_".$k));
+	      $tmp=param($p2."_".$k);
               if ($rec->{type}[$k-1] eq 'enum') {
-                $tmp=fix_param_utf8(param($p2."_".$k."_enum")) if ($tmp eq '');
+                $tmp=param($p2."_".$k."_enum") if ($tmp eq '');
               }
 	      $tmp=($tmp eq 'on' ? 't':'f') if ($type==5 && $k>1);
 	      $$new[$k]=$tmp;
@@ -640,9 +668,9 @@ sub form_check_form($$$) {
 	    for $k (1..$f) {
 	      if (param($p2."_".$k) ne $$list[$ind][$k]) {
 		$$list[$ind][$f+1]=1;
-		$tmp=fix_param_utf8(param($p2."_".$k));
+		$tmp=param($p2."_".$k);
                 if ($rec->{type}[$k-1] eq 'enum') {
-                  $tmp=fix_param_utf8(param($p2."_".$k."_enum")) if ($tmp eq '');
+                  $tmp=param($p2."_".$k."_enum") if ($tmp eq '');
                 }
 		$tmp=($tmp eq 'on' ? 't':'f') if ($type==5 && $k>1);
 		$$list[$ind][$k]=$tmp;
@@ -667,7 +695,7 @@ sub form_check_form($$$) {
       }
     }
     elsif ($type == 6 || $type == 7 || $type == 10) {
-      my $val = fix_param_utf8(param($p));
+      my $val = param($p);
       # Allow empty value if field has empty=>1
       if ($val eq '' && $rec->{empty}) {
         $data->{$tag} = -1;  # Set to -1 for empty optional groups
@@ -679,8 +707,7 @@ sub form_check_form($$$) {
     }
     elsif ($type == 13) { # Textarea (check input) 12 Apr 2017 TVu
 # Some sources say that line breaks in textarea depend on the client.
-  $val = fix_param_utf8($val);
-  $val =~ s/\r(?=\n)//gms; # cr/nl => nl (for Windows client)
+	$val =~ s/\r(?=\n)//gms; # cr/nl => nl (for Windows client)
 	$val =~ s/\r/\n/gms; # cr => nl (for Mac client)
 	my @val_arr = split(/\n/, $val);
 	my @val_arr2;

--- a/cgi/browser.cgi
+++ b/cgi/browser.cgi
@@ -6,7 +6,7 @@
 # Copyright (c) Timo Kokkonen <tjko@iki.fi>, 2001-2005.
 # All Rights Reserved.
 #
-use CGI qw/:standard *table -utf8/;
+use CGI qw/:standard *table/;
 use CGI::Carp 'fatalsToBrowser'; # debug stuff
 # use Net::Netmask;
 use NetAddr::IP; # For IPv6.
@@ -39,7 +39,11 @@ $0 = $PG_NAME;
 $debug_mode = 0;
 
 load_browser_config();
-$CGI::PARAM_UTF8 = 1 if (($BROWSER_CHARSET // '') =~ /utf-?8/i);
+# UTF-8 boundary model: decode input once (decode_cgi_params / DBD::Pg
+# pg_enable_utf8), keep wide chars internally, encode the response body once
+# here. Driven by the configured web charset, independent of the server locale.
+decode_cgi_params($BROWSER_CHARSET);
+binmode(STDOUT, ":encoding($BROWSER_CHARSET)") if $BROWSER_CHARSET;
 
 
 #%host_types=(0=>'Any type',1=>'Host',2=>'Delegation',3=>'Plain MX',

--- a/cgi/sauron.cgi
+++ b/cgi/sauron.cgi
@@ -6,7 +6,7 @@
 # Copyright (c) Timo Kokkonen <tjko@iki.fi>, 2000-2005.
 # All Rights Reserved.
 #
-use CGI qw/:standard *table -utf8/;
+use CGI qw/:standard *table/;
 use CGI::Carp 'fatalsToBrowser'; # debug stuff
 # use Net::Netmask;
 use Sauron::DB;
@@ -52,7 +52,14 @@ my ($PG_DIR,$PG_NAME) = ($0 =~ /^(.*\/)(.*)$/);
 $0 = $PG_NAME;
 
 load_config();
-$CGI::PARAM_UTF8 = 1 if (($SAURON_CHARSET // '') =~ /utf-?8/i);
+# UTF-8 handling, single-decode/single-encode boundary model:
+#   - input : decode_cgi_params() decodes request params to wide chars once
+#   - DB    : DBD::Pg pg_enable_utf8 decodes reads to wide chars
+#   - output: the binmode below encodes the response body exactly once
+# Everything in between is kept as Perl wide-character strings. Encoding is
+# driven by the configured web charset, NOT by the server locale.
+decode_cgi_params($SAURON_CHARSET);
+binmode(STDOUT, ":encoding($SAURON_CHARSET)") if $SAURON_CHARSET;
 
 my $SAURON_CGI_VER = ' $Revision: 1.204 $ $Date: 2005/01/27 09:24:44 $ ';
 $debug_mode = $SAURON_DEBUG_MODE;

--- a/t/07-utf8-encoding.t
+++ b/t/07-utf8-encoding.t
@@ -1,0 +1,147 @@
+#!/usr/bin/perl
+# t/07-utf8-encoding.t - Regression tests for the UTF-8 boundary model.
+#
+# Background: zone/host "comment" fields with diacritics were getting
+# progressively corrupted on every save (e.g. "žluťoučký" -> "Å¾luÅ¥ouÄ\x8dký").
+# Root cause: user data could reach the string-concatenation SQL builder
+# (db_encode_str + concat) as a Perl *byte* string (raw UTF-8 octets, no
+# UTF8 flag). When such a byte string is concatenated with a wide-char
+# fragment, Perl reinterprets the octets as Latin-1 and DBD::Pg
+# (client_encoding=UTF8) then encodes them to UTF-8 a second time -> mojibake.
+#
+# The fix keeps everything as Perl wide-character strings end to end:
+# decode_cgi_params() decodes request params on input (CGI.pm's own
+# -utf8/PARAM_UTF8 proved unreliable on the target server), DBD::Pg
+# pg_enable_utf8 decodes DB reads, and a single STDOUT binmode encodes the
+# response on output. The fragile fix_param_utf8() heuristic was removed.
+# These tests pin down both the input-decode and the write-path invariants.
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/..";
+use Test::More;
+use Encode qw(encode decode);
+
+# Ensure DB.pm symlink exists for transitive imports
+my $db_link = "$FindBin::Bin/../Sauron/DB.pm";
+unless (-e $db_link) {
+    symlink("DB-DBI.pm", $db_link) or die "Cannot create DB.pm symlink: $!";
+}
+
+use Sauron::DB;
+
+# "UTF8 TEST žluťoučký TEST" as proper Perl wide characters (what CGI -utf8
+# and DBD::Pg pg_enable_utf8 hand to the rest of the code).
+my $comment = "UTF8 TEST \x{17e}lu\x{165}ou\x{10d}k\x{fd} TEST";
+
+# Bytes Postgres must end up storing for that value (UTF-8, encoded once).
+my $want_bytes = encode('UTF-8', $comment);
+
+# Bytes produced by the historical double-encode bug, for an explicit
+# negative assertion ("Å¾..." = each UTF-8 octet re-encoded as Latin-1).
+my $mojibake_bytes = encode('UTF-8', decode('ISO-8859-1', $want_bytes));
+
+subtest 'db_encode_str preserves wide characters (no flag downgrade)' => sub {
+    my $enc = db_encode_str($comment);
+    like($enc, qr/\A'.*'\z/s, 'value is single-quoted');
+
+    # Extract the quoted payload and confirm it is unchanged wide-char text.
+    (my $payload = $enc) =~ s/\A'//; $payload =~ s/'\z//;
+    is($payload, $comment, 'payload equals original wide-char string');
+    ok(utf8::is_utf8($payload) || $comment !~ /[^\x00-\xff]/,
+       'wide-char string keeps its UTF8 flag through db_encode_str');
+};
+
+subtest 'concatenated SQL encodes to UTF-8 exactly once' => sub {
+    # Mimic BackEnd.pm: build an UPDATE by concatenating ASCII fragments with
+    # the encoded user value, then let DBD::Pg (client_encoding=UTF8) encode
+    # the whole statement to UTF-8.
+    my $sql = "UPDATE hosts SET comment=" . db_encode_str($comment)
+            . " WHERE id=42;";
+    my $wire = encode('UTF-8', $sql);
+
+    ok($wire =~ /comment='([^']*)'/, 'comment payload found on the wire');
+    my $stored = $1;
+
+    is($stored, $want_bytes, 'stored bytes are single-encoded UTF-8');
+    isnt($stored, $mojibake_bytes, 'stored bytes are NOT double-encoded mojibake');
+    is(decode('UTF-8', $stored), $comment, 'value round-trips back to original');
+};
+
+subtest 'save/load/save round-trip is stable (no progressive corruption)' => sub {
+    # Simulate repeated edits: each cycle writes the value, reads it back the
+    # way pg_enable_utf8 does (decode UTF-8 -> wide chars), and writes again.
+    my $value = $comment;
+    for my $cycle (1 .. 5) {
+        my $sql  = "UPDATE x SET c=" . db_encode_str($value) . ";";
+        my $wire = encode('UTF-8', $sql);
+        ($wire =~ /c='([^']*)'/) or die "cycle $cycle: payload missing";
+        my $on_disk = $1;
+        $value = decode('UTF-8', $on_disk);   # pg_enable_utf8 read path
+        is($value, $comment, "cycle $cycle: value unchanged after round-trip");
+    }
+};
+
+subtest 'input boundary: decode_cgi_params decodes octets to wide chars' => sub {
+    # The real defect: CGI.pm's -utf8/PARAM_UTF8 did NOT decode request params
+    # on the target server, so user text reached the code as raw UTF-8 octets.
+    # decode_cgi_params() now decodes them deterministically at the boundary.
+    require Sauron::CGIutil;
+    Sauron::CGIutil->import;
+
+    ok(!Sauron::CGIutil->can('fix_param_utf8'),
+       'old fix_param_utf8 heuristic is gone');
+    ok(  Sauron::CGIutil->can('decode_cgi_params'),
+       'decode_cgi_params is available');
+
+    # Simulate a GET request carrying UTF-8-encoded form data (as a browser on
+    # a UTF-8 page sends it), with CGI.pm doing no decoding of its own.
+    my $octets = encode('UTF-8', $comment);
+    my $qs = 'menu=zones&comment='
+           . join('', map { sprintf('%%%02X', ord $_) } split //, $octets);
+    local $ENV{REQUEST_METHOD} = 'GET';
+    local $ENV{QUERY_STRING}   = $qs;
+    $CGI::Q = CGI->new();   # fresh parse from %ENV for the functional interface
+
+    isnt(scalar CGI::param('comment'), $comment,
+         'raw param is undecoded octets before decode_cgi_params()');
+
+    decode_cgi_params('utf-8');
+
+    is(scalar CGI::param('comment'), $comment,
+       'param is proper wide-char text after decode_cgi_params()');
+    ok(utf8::is_utf8(scalar CGI::param('comment')),
+       'decoded param carries the UTF8 flag');
+
+    # Idempotent: a second pass must not double-decode.
+    decode_cgi_params('utf-8');
+    is(scalar CGI::param('comment'), $comment, 'second decode pass is a no-op');
+};
+
+subtest 'input boundary: repairs UTF8-flagged mojibake (the real defect)' => sub {
+    # On the target stack CGI.pm hands back the UTF-8 octets reinterpreted as
+    # Latin-1 codepoints AND with the UTF8 flag already set, e.g. "ž" (octets
+    # C5 BE) arrives as the codepoints U+00C5 U+00BE ("Å¾"). A flag check would
+    # wrongly skip it; decode_cgi_params() must still repair it.
+    require Sauron::CGIutil;
+    Sauron::CGIutil->import;
+
+    my $mojibake = decode('ISO-8859-1', encode('UTF-8', $comment)); # octets as L1
+    ok(utf8::is_utf8($mojibake), 'mojibake test value carries the UTF8 flag');
+    isnt($mojibake, $comment, 'mojibake value differs from the original');
+
+    local $ENV{REQUEST_METHOD} = 'GET';
+    local $ENV{QUERY_STRING}   = 'menu=zones';
+    $CGI::Q = CGI->new();
+    CGI::param('comment', $mojibake);   # inject the flagged-mojibake value
+
+    decode_cgi_params('utf-8');
+    is(scalar CGI::param('comment'), $comment,
+       'flagged mojibake is repaired to the original text');
+
+    # And stable across a further pass (mirrors repeated Apply/Add round trips).
+    decode_cgi_params('utf-8');
+    is(scalar CGI::param('comment'), $comment, 'repair is stable / idempotent');
+};
+
+done_testing();

--- a/t/07-utf8-encoding.t
+++ b/t/07-utf8-encoding.t
@@ -1,0 +1,168 @@
+#!/usr/bin/perl
+# t/07-utf8-encoding.t - Regression tests for the UTF-8 boundary model.
+#
+# Background: zone/host "comment" fields with diacritics were getting
+# progressively corrupted on every save (e.g. "žluťoučký" -> "Å¾luÅ¥ouÄ\x8dký").
+# Root cause: user data could reach the string-concatenation SQL builder
+# (db_encode_str + concat) as a Perl *byte* string (raw UTF-8 octets, no
+# UTF8 flag). When such a byte string is concatenated with a wide-char
+# fragment, Perl reinterprets the octets as Latin-1 and DBD::Pg
+# (client_encoding=UTF8) then encodes them to UTF-8 a second time -> mojibake.
+#
+# The fix keeps everything as Perl wide-character strings end to end:
+# decode_cgi_params() decodes request params on input (CGI.pm's own
+# -utf8/PARAM_UTF8 proved unreliable on the target server), DBD::Pg
+# pg_enable_utf8 decodes DB reads, and a single STDOUT binmode encodes the
+# response on output. The fragile fix_param_utf8() heuristic was removed.
+# These tests pin down both the input-decode and the write-path invariants.
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/..";
+use Test::More;
+use Encode qw(encode decode);
+
+# Ensure DB.pm symlink exists for transitive imports
+my $db_link = "$FindBin::Bin/../Sauron/DB.pm";
+unless (-e $db_link) {
+    symlink("DB-DBI.pm", $db_link) or die "Cannot create DB.pm symlink: $!";
+}
+
+use Sauron::DB;
+
+# "UTF8 TEST žluťoučký TEST" as proper Perl wide characters (what CGI -utf8
+# and DBD::Pg pg_enable_utf8 hand to the rest of the code).
+my $comment = "UTF8 TEST \x{17e}lu\x{165}ou\x{10d}k\x{fd} TEST";
+
+# Bytes Postgres must end up storing for that value (UTF-8, encoded once).
+my $want_bytes = encode('UTF-8', $comment);
+
+# Bytes produced by the historical double-encode bug, for an explicit
+# negative assertion ("Å¾..." = each UTF-8 octet re-encoded as Latin-1).
+my $mojibake_bytes = encode('UTF-8', decode('ISO-8859-1', $want_bytes));
+
+subtest 'db_encode_str preserves wide characters (no flag downgrade)' => sub {
+    my $enc = db_encode_str($comment);
+    like($enc, qr/\A'.*'\z/s, 'value is single-quoted');
+
+    # Extract the quoted payload and confirm it is unchanged wide-char text.
+    (my $payload = $enc) =~ s/\A'//; $payload =~ s/'\z//;
+    is($payload, $comment, 'payload equals original wide-char string');
+    ok(utf8::is_utf8($payload) || $comment !~ /[^\x00-\xff]/,
+       'wide-char string keeps its UTF8 flag through db_encode_str');
+};
+
+subtest 'concatenated SQL encodes to UTF-8 exactly once' => sub {
+    # Mimic BackEnd.pm: build an UPDATE by concatenating ASCII fragments with
+    # the encoded user value, then let DBD::Pg (client_encoding=UTF8) encode
+    # the whole statement to UTF-8.
+    my $sql = "UPDATE hosts SET comment=" . db_encode_str($comment)
+            . " WHERE id=42;";
+    my $wire = encode('UTF-8', $sql);
+
+    ok($wire =~ /comment='([^']*)'/, 'comment payload found on the wire');
+    my $stored = $1;
+
+    is($stored, $want_bytes, 'stored bytes are single-encoded UTF-8');
+    isnt($stored, $mojibake_bytes, 'stored bytes are NOT double-encoded mojibake');
+    is(decode('UTF-8', $stored), $comment, 'value round-trips back to original');
+};
+
+subtest 'save/load/save round-trip is stable (no progressive corruption)' => sub {
+    # Simulate repeated edits: each cycle writes the value, reads it back the
+    # way pg_enable_utf8 does (decode UTF-8 -> wide chars), and writes again.
+    my $value = $comment;
+    for my $cycle (1 .. 5) {
+        my $sql  = "UPDATE x SET c=" . db_encode_str($value) . ";";
+        my $wire = encode('UTF-8', $sql);
+        ($wire =~ /c='([^']*)'/) or die "cycle $cycle: payload missing";
+        my $on_disk = $1;
+        $value = decode('UTF-8', $on_disk);   # pg_enable_utf8 read path
+        is($value, $comment, "cycle $cycle: value unchanged after round-trip");
+    }
+};
+
+subtest 'input boundary: decode_cgi_params decodes octets to wide chars' => sub {
+    # The real defect: CGI.pm's -utf8/PARAM_UTF8 did NOT decode request params
+    # on the target server, so user text reached the code as raw UTF-8 octets.
+    # decode_cgi_params() now decodes them deterministically at the boundary.
+    require Sauron::CGIutil;
+    Sauron::CGIutil->import;
+
+    ok(!Sauron::CGIutil->can('fix_param_utf8'),
+       'old fix_param_utf8 heuristic is gone');
+    ok(  Sauron::CGIutil->can('decode_cgi_params'),
+       'decode_cgi_params is available');
+
+    # Simulate a GET request carrying UTF-8-encoded form data (as a browser on
+    # a UTF-8 page sends it), with CGI.pm doing no decoding of its own.
+    my $octets = encode('UTF-8', $comment);
+    my $qs = 'menu=zones&comment='
+           . join('', map { sprintf('%%%02X', ord $_) } split //, $octets);
+    local $ENV{REQUEST_METHOD} = 'GET';
+    local $ENV{QUERY_STRING}   = $qs;
+    $CGI::Q = CGI->new();   # fresh parse from %ENV for the functional interface
+
+    isnt(scalar CGI::param('comment'), $comment,
+         'raw param is undecoded octets before decode_cgi_params()');
+
+    decode_cgi_params('utf-8');
+
+    is(scalar CGI::param('comment'), $comment,
+       'param is proper wide-char text after decode_cgi_params()');
+    ok(utf8::is_utf8(scalar CGI::param('comment')),
+       'decoded param carries the UTF8 flag');
+
+    # Idempotent: a second pass must not double-decode.
+    decode_cgi_params('utf-8');
+    is(scalar CGI::param('comment'), $comment, 'second decode pass is a no-op');
+};
+
+subtest 'input boundary: repairs UTF8-flagged mojibake (the real defect)' => sub {
+    # On the target stack CGI.pm hands back the UTF-8 octets reinterpreted as
+    # Latin-1 codepoints AND with the UTF8 flag already set, e.g. "ž" (octets
+    # C5 BE) arrives as the codepoints U+00C5 U+00BE ("Å¾"). A flag check would
+    # wrongly skip it; decode_cgi_params() must still repair it.
+    require Sauron::CGIutil;
+    Sauron::CGIutil->import;
+
+    my $mojibake = decode('ISO-8859-1', encode('UTF-8', $comment)); # octets as L1
+    ok(utf8::is_utf8($mojibake), 'mojibake test value carries the UTF8 flag');
+    isnt($mojibake, $comment, 'mojibake value differs from the original');
+
+    local $ENV{REQUEST_METHOD} = 'GET';
+    local $ENV{QUERY_STRING}   = 'menu=zones';
+    $CGI::Q = CGI->new();
+    CGI::param('comment', $mojibake);   # inject the flagged-mojibake value
+
+    decode_cgi_params('utf-8');
+    is(scalar CGI::param('comment'), $comment,
+       'flagged mojibake is repaired to the original text');
+
+    # And stable across a further pass (mirrors repeated Apply/Add round trips).
+    decode_cgi_params('utf-8');
+    is(scalar CGI::param('comment'), $comment, 'repair is stable / idempotent');
+};
+
+subtest 'no module re-introduces CGI -utf8 (single-authority model)' => sub {
+    # decode_cgi_params() is the sole input-decoder. CGI.pm's -utf8 sets the
+    # process-global $CGI::PARAM_UTF8, so a single stray import re-enables it
+    # everywhere and makes the boundary model inconsistent again. Guard against
+    # that drift.
+    my $root = "$FindBin::Bin/..";
+    my @files = (glob("$root/Sauron/*.pm"), glob("$root/Sauron/CGI/*.pm"),
+                 glob("$root/cgi/*.cgi"));
+    my @offenders;
+    for my $f (@files) {
+        open(my $fh, '<', $f) or next;
+        while (my $line = <$fh>) {
+            next if $line =~ /^\s*#/;
+            push @offenders, $f if $line =~ /\buse\s+CGI\b.*-utf8/;
+        }
+        close($fh);
+    }
+    is_deeply(\@offenders, [], 'no use CGI ... -utf8 imports remain')
+        or diag("offending files: @offenders");
+};
+
+done_testing();


### PR DESCRIPTION
Zone/host comments with diacritics were double-encoded and got progressively worse on every save -- including via form-reloading "Add" buttons -- e.g. "žluťoučký" (bright yellow) -> "Å¾luÅ¥ouÄ\x8dký".

Root cause (diagnosed empirically against the live CGI.pm + module stack): incoming request parameters arrive as the raw UTF-8 octets reinterpreted as Latin-1 codepoints, with the UTF8 flag already set -- e.g. "ž" (octets C5 BE) becomes the codepoints U+00C5 U+00BE ("Å¾"). Handed to `db_encode_str()`/`DBD::Pg` (client_encoding=UTF8) it is encoded to UTF-8 a second time, double-encoding the value on every write. The earlier fix_param_utf8() heuristic only repaired this inside `form_check_form()`, so any path that bypassed it (reload buttons, sticky form re-render) still corrupted the text, and a flag-based guard skips the already-flagged value entirely.

Establish one consistent representation: Perl wide-character strings, end to end.

- Add `decode_cgi_params()` in `Sauron::CGIutil`: normalize every incoming CGI parameter once, at the request boundary, before any processing or re-rendering. Repair = map codepoints back to octets (encode ISO-8859-1) and decode as UTF-8; FB_CROAK makes it self-guarding and idempotent (already-correct wide text and non-UTF-8 values are left untouched), so repeated `Apply`/`Add` round trips stay stable.
- Call it from `sauron.cgi` and `browser.cgi`; drop the unreliable `-utf8` import and `$CGI::PARAM_UTF8` assignment.
- Remove the `fix_param_utf8()` heuristic and its call sites in `CGIutil.pm`.
- Encode the response body exactly once via an explicit STDOUT binmode driven by the configured web charset (independent of server locale).
- Keep `DBD::Pg pg_enable_utf8` + UTF8 `client_encoding` for DB reads/writes.
- Add `t/07-utf8-encoding.t` covering the UTF8-flagged mojibake case, the write-path invariant and round-trip stability.