### PR TITLE
Fix invalid empty TXT records for type=13 hosts without cname_txt

### DIFF
--- a/Sauron/UtilZone.pm
+++ b/Sauron/UtilZone.pm
@@ -540,8 +540,12 @@ sub bind_fmt_long_data($$) {
   my $spaces = shift @_;
   my $indentation = ' ' x ($spaces - 1);
 
+  # Empty data would otherwise fall through to the multi-line branch below
+  # and emit an invalid empty "( )" record. Return a valid empty TXT string.
+  return "\"\"\n" unless (defined($data) && $data ne '');
+
   # Converting text to a sequence of bytes (DNS operates with bytes)
-  my $bytes = encode('UTF-8', $data); 
+  my $bytes = encode('UTF-8', $data);
   #print "$data\n";
   my @chunks;
   while (length $bytes) {

--- a/sauron
+++ b/sauron
@@ -1737,11 +1737,15 @@ sub make_dns() {
         $ttl=$q[$i][1];
         $ttl='' unless ($ttl > 0);
         $val=$q[$i][3];
+        # type=13 hosts may keep their TXT data in txt_entries (legacy path
+        # above) and have an empty/NULL cname_txt. Skip those, otherwise an
+        # empty value produces an invalid "( )" TXT record. ** MSv 2026-06-20
+        next unless (defined($val) && $val ne '');
         $val =~ s/\"//g;
 
         $padding = length(sprintf $ZFORMAT, $domain, $ttl, $class, '');
-        printf ZONEFILE $ZFORMAT, $domain,$ttl,$class,'TXT', 
-            bind_fmt_long_data("$val", $padding) 
+        printf ZONEFILE $ZFORMAT, $domain,$ttl,$class,'TXT',
+            bind_fmt_long_data("$val", $padding)
             if ($bind_conf);
         $val=~ s/:/\\072/g;
         printf TINYDNSFILE "'$zonename\:$val\:$ttl\:\:\n" if ($tiny_conf);


### PR DESCRIPTION
The "Standalone TXT hosts (type=13)" section added in c3ff415 emitted a TXT record for every type=13 host, even those with a NULL/empty `cname_txt` (e.g. hosts whose data lives in `txt_entries`, or empty entries). An empty value produced an invalid "( )" block, making named-checkzone fail with "unexpected end of input" and aborting zone generation.

Observed on zone `cesnet.asia` where `hosts _dmarc`, `test` and `test2` (type=13, cname_txt NULL) generated empty parenthesized TXT records:

    _dmarc    IN  TXT    (
                         )

Fixes:
- sauron: skip type=13 hosts with an empty/NULL cname_txt in the standalone TXT section.
- Sauron/UtilZone.pm: `bind_fmt_long_data()` now returns a valid empty TXT string ("") instead of empty parentheses when given empty input, as defense in depth.