### PR TITLE
Fix github actions when stopping containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
           POSTGRES_PASSWORD: "${{ secrets.PROJECT_SEED }}.${{ github.run_id }}.${{ github.run_number }}"
         ports: [5432:5432]
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U sauronuser -d sauron_test"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/import-blocklist
+++ b/import-blocklist
@@ -1156,7 +1156,7 @@ sub delete_txt_hosts_for_domain {
     my $query = "SELECT id, domain FROM hosts " .
                 "WHERE zone = $zoneid AND type = 13 " .
                 "AND comment LIKE " . db_encode_str($txt_comment_prefix . '%') . " " .
-                "AND domain LIKE " . db_encode_str($like_pattern) . " ESCAPE '\\\\'";
+                "AND domain LIKE " . db_encode_str($like_pattern) . " ESCAPE E'\\\\'";
     
     my @rows;
     db_query($query, \@rows);


### PR DESCRIPTION
  Fixes two unrelated issues surfaced by the PostgreSQL service logs in CI. They
  are independent and split into two commits.

  ## Changes

  ### 1. Fix invalid `ESCAPE` clause in blocklist TXT deletion query

  `delete_txt_hosts_for_domain()` in `import-blocklist` generated SQL containing
  `ESCAPE '\\'`. Under `standard_conforming_strings = on` (the default since
  PostgreSQL 9.1, including `postgres:15`), `'\\'` is a **two-character** string,
  while the `ESCAPE` clause requires exactly one character. The query therefore
  failed with:
  
  ERROR:  invalid escape string
  HINT:  Escape string must be empty or one character.

  As a result the matching standalone TXT records were silently left undeleted.
  
  The fix uses the escape-string form `E'\\'`, so the escape character is a single
  backslash regardless of the `standard_conforming_strings` setting — consistent
  with how the `LIKE` value itself is rendered.

  This is a **functional** fix.

  ### 2. Silence `role "root" does not exist` in CI postgres health check
 
  The `postgres` service health check ran `pg_isready` without specifying a user,
  so it connected as the container's OS user (`root`), which is not a defined role.
  The check still passed (the server was responding), but every interval logged:

  FATAL:  role "root" does not exist
 
  The health command now passes the configured role and database
  (`pg_isready -U sauronuser -d sauron_test`), removing the noise.

  This is a **cosmetic / log-hygiene** fix only.

  ## Impact

  - No behavior change for end users beyond restoring the intended TXT-record
    cleanup in `import-blocklist`.
  - CI postgres logs are now clean of spurious `FATAL` / `ERROR` lines, making the
    *Stop containers* output easier to read.
   
  ## Testing

  - `perl -c import-blocklist` passes.
  - CI workflow runs green with no `invalid escape string` or
    `role "root" does not exist` entries in the postgres service logs.
