### PR TITLE
Fix TSIG key selection for modern HMAC-SHA algorithms in AXFR forms

### DIFF
--- a/Sauron/CGI/ACLs.pm
+++ b/Sauron/CGI/ACLs.pm
@@ -24,7 +24,10 @@ $VERSION = '$Id:$ ';
 
 
 my %key_algorithm_hash = (0=>'Reserved', 1=>'RSA/MD5',2=>'Diffie-Hellman',
-			  3=>'DSA',4=>'ECC',157=>'HMAC MD5');
+			  3=>'DSA',4=>'ECC',
+			  157=>'HMAC-MD5', 158=>'HMAC-SHA1',
+			  159=>'HMAC-SHA256', 160=>'HMAC-SHA384',
+			  161=>'HMAC-SHA512');
 
 
 my %acl_form=(

--- a/Sauron/CGIutil.pm
+++ b/Sauron/CGIutil.pm
@@ -1404,7 +1404,7 @@ sub form_magic($$$) {
 	my(@aml_key_l,%aml_key_h,@aml_acl_l,%aml_acl_h);
 	get_acl_list($serverid,\%aml_acl_h,\@aml_acl_l,
 		     ($rec->{acl_mode} == 1 ? param($prefix."_id") : 0));
-	get_key_list($serverid,\%aml_key_h,\@aml_key_l,157);
+	get_key_list($serverid,\%aml_key_h,\@aml_key_l,-1);
 	print td($rec->{name}),'<td><table class="s-form__multi"><tr>',
 	      th(["Type","Op","Rule","Comments"]);
 	$a=param($p1."_count");


### PR DESCRIPTION
Commit af9fdb3 added HMAC-SHA1/256/384/512 support (algorithm ids 158-161) and taught `get_key_list()` a `-1` mode that returns the whole TSIG family (algorithm 157-161). Its only caller was never updated and still passed the literal 157, so the AML key dropdown in the Servers and Zones AXFR forms only listed HMAC-MD5 keys. Keys created with the new algorithms never appeared and the menu showed only `--None--`.

Sauron/CGIutil.pm:
- Pass `-1` to `get_key_list()` for the `ftype==12` (AML) field so the whole TSIG family is offered, not just HMAC-MD5.

Sauron/CGI/ACLs.pm:
- Extend `%key_algorithm_hash` with the SHA algorithms so `browse_keys()` shows the algorithm name instead of a blank column. Names aligned with keygen.