### PR TITLE
Allow TSIG key names with dots per RFC8945

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,18 @@
 0.9.0 (beta)
 
+	- Enforce RFC8945-compliant TSIG key name validation [svamberg]
+	  - Add valid_tsig_keyname() to Sauron::Util for DNS domain name validation
+	    (relative or FQDN, allowing alphanumeric, hyphens, underscores, dots)
+	  - keygen now uses valid_tsig_keyname() instead of valid_texthandle()
+	    to accept RFC8945-style key names with dots (e.g. <id>.<fqdn>)
+	  - Validation rules: labels must start with alphanumeric, no consecutive
+	    dots, no leading/trailing hyphens on labels, trailing dot allowed
+	  - BREAKING CHANGE: Existing TSIG keys with names starting with '_' or
+	    ending with '-' are now rejected. Check existing keys before upgrade:
+	      SELECT name FROM keys WHERE type=1 AND (name ~ '^_' OR name ~ '-$');
+	  - Unit tests: t/01-util.t (valid_tsig_keyname subtest)
+	  - Documentation: docs/tsig-key-management.txt, README.upgrade
+
 	- Add modern TSIG algorithm support (HMAC-SHA1/256/384/512) [svamberg]
 	  - keygen: generate keys with --algorithm (default HMAC-SHA256) and
 	    switch from dnssec-keygen to BIND's tsig-keygen, which is required

--- a/README.upgrade
+++ b/README.upgrade
@@ -100,6 +100,51 @@ Always run a database backup before mass text repair.
 
 
 
+TSIG KEY NAME VALIDATION (RFC8945, 0.9.0)
+
+Sauron 0.9.0 enforces RFC8945-compliant TSIG key name validation. The new
+valid_tsig_keyname() validator replaces the previous valid_texthandle() and
+requires TSIG key names to follow DNS domain name rules:
+
+Validation rules:
+ - Allowed characters: alphanumeric (A-Z, a-z, 0-9), hyphens (-), 
+   underscores (_), and dots (.)
+ - Labels (parts between dots) must start with alphanumeric
+ - Labels cannot end with hyphen
+ - No consecutive dots
+ - Trailing dot is allowed (FQDN notation, e.g. "key.example.com.")
+ - Both relative names ("key1") and FQDNs ("key1.example.com") are accepted
+
+BREAKING CHANGE:
+If your database contains TSIG keys with names that violate these rules,
+the keygen utility will reject them after upgrade. Specifically:
+
+ - Names starting with underscore: "_key", "_transfer"
+ - Names ending with hyphen: "key-", "transfer-"
+
+Before upgrading, check for non-compliant key names:
+
+  sudo -u postgres -- psql sauron -P pager=off -c \
+    "SELECT id, name FROM keys WHERE type=1 AND protocol=2 AND (name ~ '^_' OR name ~ '-$');"
+
+If any keys are returned, you have two options:
+
+Option A: Rename the keys before upgrade
+  sudo -u postgres -- psql sauron -P pager=off -c \
+    "UPDATE keys SET name='renamed-key' WHERE id=<id>;"
+  
+  Then update any DNS server configurations that reference the old key name.
+
+Option B: Temporarily relax validation (not recommended)
+  Modify Sauron/Util.pm valid_tsig_keyname() to allow the problematic patterns,
+  then plan a migration to compliant names.
+
+Always backup your database before making changes to TSIG key names:
+
+  pg_dump sauron > sauron-backup-$(date +%Y%m%d).sql
+
+
+
 GENERAL UPGRADE PROCEDURE
 
  1) Make backup of your database!

--- a/Sauron/Util.pm
+++ b/Sauron/Util.pm
@@ -38,6 +38,7 @@ $VERSION = '$Id:$ ';
 	     valid_domainname
              valid_hex
 	     valid_texthandle
+	     valid_tsig_keyname
              cidrok
              cidr4ok
              cidr6ok
@@ -80,10 +81,10 @@ $VERSION = '$Id:$ ';
 	     new_serial
 	     decode_daterange_str
 	     utimefmt
-             url2link
-         is_iaid
-         trim
-         dhcpduid
+         url2link
+     is_iaid
+     trim
+     dhcpduid
 	     tsig_secret_encrypt
 	     tsig_secret_decrypt
 	    );
@@ -209,6 +210,35 @@ sub valid_texthandle($) {
   my($str) = @_;
 
   return ($str =~ /^[a-zA-Z0-9_\-]+$/ ? 1 : 0);
+}
+
+# Validate TSIG key name according to RFC8945.
+# TSIG key name should be a valid domain name format: <id>.<fqdn>
+# Allowed characters: alphanumeric, hyphens, dots, underscores
+# - Labels (parts between dots) must start with alphanumeric
+# - No consecutive dots
+# - Trailing dot is allowed (FQDN notation)
+sub valid_tsig_keyname($) {
+  my($str) = @_;
+  
+  return 0 unless (defined $str && $str ne '');
+  return 0 if ($str =~ /^\./);                   # cannot start with dot
+  return 0 if ($str =~ /\.\./);                  # no consecutive dots
+  
+  # Strip trailing dot if present (FQDN notation)
+  $str =~ s/\.$//;
+  return 0 if ($str eq '');                      # was just a single dot
+  
+  # Check each label (part between dots)
+  my @labels = split(/\./, $str);
+  for my $label (@labels) {
+    return 0 if ($label eq '');                  # empty label
+    return 0 unless ($label =~ /^[a-zA-Z0-9_\-]+$/);  # valid chars only
+    return 0 unless ($label =~ /^[a-zA-Z0-9]/);  # must start with alphanumeric
+    return 0 if ($label =~ /-$/);                # cannot end with hyphen
+  }
+  
+  return 1;
 }
 
 # Change an URL to a link, not showing "http(s)://", possible parameters and fragment identifier.

--- a/Sauron/Util.pm
+++ b/Sauron/Util.pm
@@ -81,10 +81,10 @@ $VERSION = '$Id:$ ';
 	     new_serial
 	     decode_daterange_str
 	     utimefmt
-         url2link
-     is_iaid
-     trim
-     dhcpduid
+             url2link
+         is_iaid
+         trim
+         dhcpduid
 	     tsig_secret_encrypt
 	     tsig_secret_decrypt
 	    );
@@ -213,7 +213,7 @@ sub valid_texthandle($) {
 }
 
 # Validate TSIG key name according to RFC8945.
-# TSIG key name should be a valid domain name format: <id>.<fqdn>
+# TSIG key name is a DNS domain name (relative or FQDN), e.g. <id>.<fqdn>
 # Allowed characters: alphanumeric, hyphens, dots, underscores
 # - Labels (parts between dots) must start with alphanumeric
 # - No consecutive dots

--- a/docs/tsig-key-management.txt
+++ b/docs/tsig-key-management.txt
@@ -219,11 +219,27 @@ BEST PRACTICES
    - Use --regen for automated key rotation
    - Document key creation/rotation dates in comments
 
-3. Key Naming:
-   - Use descriptive names indicating purpose:
-     * axfr-key, ixfr-key (zone transfers)
-     * ddns-key, update-key (dynamic updates)
-     * <zone>-key (zone-specific keys)
+3. Key Naming (RFC8945 compliant):
+   - TSIG key names must follow DNS domain name rules per RFC8945
+   - Format: relative name (e.g. "key1") or FQDN (e.g. "key1.example.com.")
+   - Allowed characters: alphanumeric (A-Z, a-z, 0-9), hyphens, underscores, dots
+   - Labels (parts between dots) must:
+     * Start with alphanumeric character
+     * Not end with hyphen
+   - No consecutive dots allowed
+   - Trailing dot is optional (FQDN notation)
+   - Examples of valid names:
+     * "transfer-key", "ddns-key", "axfr-key.example.com."
+     * "1.key.example.com" (numeric prefix allowed)
+     * "key_1" (underscore allowed, but not as first character)
+   - Invalid names (rejected by keygen):
+     * "_key" (starts with underscore)
+     * "key-" (ends with hyphen)
+     * "key..example.com" (consecutive dots)
+     * "-key.example.com" (label starts with hyphen)
+   - Check existing keys before upgrade (0.9.0+):
+     SELECT name FROM keys WHERE type=1 AND protocol=2
+       AND (name ~ '^_' OR name ~ '-$');
 
 4. Access Control:
    - Limit key regeneration/deletion to authorized administrators

--- a/keygen
+++ b/keygen
@@ -120,7 +120,7 @@ sub getname($) {
 	print "Key name: ";
 	chomp($ans = <STDIN>);
     }
-    fatal("invalid key name: $ans") unless (valid_texthandle($ans));
+    fatal("invalid key name: $ans") unless (valid_tsig_keyname($ans));
     return $ans;
 }
 
@@ -185,7 +185,7 @@ sub generate_key($$$$) {
 	unless (-x $tsig_prog);
 
     # Use the list form of open() so the key name cannot be interpreted by
-    # a shell (it is already validated by valid_texthandle(), but be safe).
+    # a shell (it is already validated by valid_tsig_keyname(), but be safe).
     open(PIPE,"-|",$tsig_prog,"-a",$alg_name,"--",$name) ||
 	fatal("failed to run $tsig_prog");
     while(<PIPE>) {

--- a/t/01-util.t
+++ b/t/01-util.t
@@ -56,7 +56,7 @@ subtest 'valid_texthandle' => sub {
 # valid_tsig_keyname (RFC8945 compliant TSIG key names)
 # =========================================================================
 subtest 'valid_tsig_keyname' => sub {
-    # Valid TSIG key names per RFC8945 format <id>.<fqdn>
+    # Valid TSIG key names (relative or FQDN); RFC8945 uses domain names such as <id>.<fqdn>
     ok(valid_tsig_keyname('key1.example.com'), 'simple FQDN format');
     ok(valid_tsig_keyname('1.key.example.com'), 'numeric prefix label');
     ok(valid_tsig_keyname('tsig-key.example.net'), 'label with hyphen');

--- a/t/01-util.t
+++ b/t/01-util.t
@@ -53,6 +53,31 @@ subtest 'valid_texthandle' => sub {
 };
 
 # =========================================================================
+# valid_tsig_keyname (RFC8945 compliant TSIG key names)
+# =========================================================================
+subtest 'valid_tsig_keyname' => sub {
+    # Valid TSIG key names per RFC8945 format <id>.<fqdn>
+    ok(valid_tsig_keyname('key1.example.com'), 'simple FQDN format');
+    ok(valid_tsig_keyname('1.key.example.com'), 'numeric prefix label');
+    ok(valid_tsig_keyname('tsig-key.example.net'), 'label with hyphen');
+    ok(valid_tsig_keyname('key_1.example.com'), 'label with underscore');
+    ok(valid_tsig_keyname('host1'), 'single label without dot');
+    ok(valid_tsig_keyname('mykey'), 'simple alphanumeric');
+    ok(valid_tsig_keyname('key.example.com.'), 'FQDN with trailing dot');
+    ok(valid_tsig_keyname('1.sner-hub.flab.cesnet.cz.'), 'complex FQDN with trailing dot');
+    
+    # Invalid cases
+    ok(!valid_tsig_keyname(''), 'rejects empty string');
+    ok(!valid_tsig_keyname('.example.com'), 'rejects leading dot');
+    ok(!valid_tsig_keyname('key..example.com'), 'rejects consecutive dots');
+    ok(!valid_tsig_keyname('key name.example.com'), 'rejects spaces');
+    ok(!valid_tsig_keyname('-key.example.com'), 'rejects label starting with hyphen');
+    ok(!valid_tsig_keyname('key-'), 'rejects label ending with hyphen');
+    ok(!valid_tsig_keyname('key!example.com'), 'rejects special characters');
+    ok(!valid_tsig_keyname('.'), 'rejects single dot');
+};
+
+# =========================================================================
 # IPv4 CIDR validation (cidr4ok)
 # =========================================================================
 subtest 'cidr4ok' => sub {


### PR DESCRIPTION
Add a dedicated `valid_tsig_keyname()` validator to `Sauron::Util` that accepts RFC8945-style key names such as `<id>.<fqdn>`, including the trailing dot form. Use it in `keygen` instead of `valid_texthandle()`, which only allows a flat set of alphanumerics, underscores and dashes and therefore rejected the dot.

Also add unit tests for the new validator covering valid names, FQDN trailing dots, and common invalid inputs.