### PR TITLE
Fix catalog zone version record owner name (RFC 9432)

### DIFF
--- a/import-catalog-zone
+++ b/import-catalog-zone
@@ -148,8 +148,8 @@ print "Detected source catalog origin: $source_origin\n" if ($opt_verbose);
 ##############################
 # Parse catalog zone contents (RFC 9432)
 #
-# Structure:
-#   version.catalog.<origin>  TXT "2"
+# Structure (RFC 9432):
+#   version.<origin>  TXT "2"
 #   <uuid>.zones.<origin>  PTR <member-zone-name>.
 #   group.<uuid>.zones.<origin>  TXT "<group-name>"
 #
@@ -158,9 +158,9 @@ print "Detected source catalog origin: $source_origin\n" if ($opt_verbose);
 #   group.<uuid>.zones.catalog.<origin>  TXT "<group-name>"
 
 # Verify catalog version
-# Sauron generator writes 'version.catalog' relative to zone origin, so
-# after FQDN expansion it becomes 'version.catalog.<origin>'.
-$version_key = "version.catalog.$source_origin";
+# Sauron generator writes 'version' relative to zone origin, so
+# after FQDN expansion it becomes 'version.<origin>'.
+$version_key = "version.$source_origin";
 if ($zonedata{$version_key} && @{$zonedata{$version_key}{TXT}} > 0) {
     $catver = $zonedata{$version_key}{TXT}[0];
     $catver =~ s/^"(.*)"$/$1/;  # strip quotes if present
@@ -559,7 +559,7 @@ sub detect_catalog_origin($$$) {
 	return $soa_candidates[0] if (@soa_candidates == 1);
 
 	@version_candidates = sort map {
-	/^version\.catalog\.(.+)$/ ? $1 : ()
+	/^version\.(.+)$/ ? $1 : ()
 	} keys %{$zonedata};
 	return $version_candidates[0] if (@version_candidates == 1);
 

--- a/import-catalog-zone
+++ b/import-catalog-zone
@@ -158,9 +158,12 @@ print "Detected source catalog origin: $source_origin\n" if ($opt_verbose);
 #   group.<uuid>.zones.catalog.<origin>  TXT "<group-name>"
 
 # Verify catalog version
-# Sauron generator writes 'version' relative to zone origin, so
-# after FQDN expansion it becomes 'version.<origin>'.
+# Accept both canonical RFC 9432 form (version.<origin>) and
+# legacy Sauron form (version.catalog.<origin>) for backward compatibility.
 $version_key = "version.$source_origin";
+unless ($zonedata{$version_key} && @{$zonedata{$version_key}{TXT}} > 0) {
+    $version_key = "version.catalog.$source_origin";
+}
 if ($zonedata{$version_key} && @{$zonedata{$version_key}{TXT}} > 0) {
     $catver = $zonedata{$version_key}{TXT}[0];
     $catver =~ s/^"(.*)"$/$1/;  # strip quotes if present
@@ -559,7 +562,7 @@ sub detect_catalog_origin($$$) {
 	return $soa_candidates[0] if (@soa_candidates == 1);
 
 	@version_candidates = sort map {
-	/^version\.(.+)$/ ? $1 : ()
+	/^version\.(?:catalog\.)?(.+)$/ ? $1 : ()
 	} keys %{$zonedata};
 	return $version_candidates[0] if (@version_candidates == 1);
 

--- a/sauron
+++ b/sauron
@@ -1785,7 +1785,7 @@ sub make_dns() {
         print ZONEFILE ";\n; Catalog zone members (RFC 9432)\n;\n";
 
         # Version metadata record
-        print ZONEFILE "version.catalog\t$ttl\tIN\tTXT\t\"2\"\n";
+        print ZONEFILE "version\t$ttl\tIN\tTXT\t\"2\"\n";
 
         # Member zone PTR records
         for $i (0 .. $#{$catalog_rec->{members}}) {
@@ -1807,7 +1807,7 @@ sub make_dns() {
         }
       } else {
         print ZONEFILE ";\n; Catalog zone (no members currently)\n;\n" if ($bind_conf);
-        print ZONEFILE "version.catalog\t$ttl\tIN\tTXT\t\"2\"\n" if ($bind_conf);
+        print ZONEFILE "version\t$ttl\tIN\tTXT\t\"2\"\n" if ($bind_conf);
       }
     }
 
@@ -1824,7 +1824,7 @@ sub make_dns() {
 
       if (@comps > 0) {
         print ZONEFILE ";\n; Aggregate catalog zone members (RFC 9432)\n;\n";
-        print ZONEFILE "version.catalog\t$ttl\tIN\tTXT\t\"2\"\n";
+        print ZONEFILE "version\t$ttl\tIN\tTXT\t\"2\"\n";
 
         for my $comp (@comps) {
           my ($src_id, $src_name, $prio) = @$comp;
@@ -1869,7 +1869,7 @@ sub make_dns() {
         }
       } else {
         print ZONEFILE ";\n; Aggregate catalog zone (no source catalogs configured)\n;\n";
-        print ZONEFILE "version.catalog\t$ttl\tIN\tTXT\t\"2\"\n";
+        print ZONEFILE "version\t$ttl\tIN\tTXT\t\"2\"\n";
       }
     }
 

--- a/t/13-catalog-aggregate.t
+++ b/t/13-catalog-aggregate.t
@@ -350,9 +350,9 @@ subtest 'generate aggregate zone file' => sub {
     my $content = do { local $/; <$fh> };
     close($fh);
 
-    # Verify version record
-    like($content, qr/version\.catalog\s+.*\s+IN\s+TXT\s+"2"/,
-         'contains version.catalog TXT "2"');
+    # Verify version record (relative to zone origin: version.<aggregate-zone-name>)
+    like($content, qr/^version\s+.*\s+IN\s+TXT\s+"2"/m,
+         'contains version TXT "2"');
 
     # Verify members from catalog1
     like($content, qr/PTR\s+alpha\.example\.com\./,
@@ -449,7 +449,7 @@ $ORIGIN catalog1.example.com.
 @	IN	SOA	ns1.example.com. admin.example.com. (
 		2024020101 3600 900 604800 0 )
 	IN	NS	invalid.
-version.catalog		IN	TXT	"2"
+version		IN	TXT	"2"
 uuid-002.zones	IN	PTR	beta.example.com.
 uuid-003.zones	IN	PTR	shared.example.com.
 group.uuid-002.zones	IN	TXT	"backend"
@@ -502,7 +502,7 @@ $ORIGIN catalog1.example.com.
 @	IN	SOA	ns1.example.com. admin.example.com. (
 		2024030101 3600 900 604800 0 )
 	IN	NS	invalid.
-version.catalog		IN	TXT	"2"
+version		IN	TXT	"2"
 uuid-002.zones	IN	PTR	beta.example.com.
 uuid-003.zones	IN	PTR	shared.example.com.
 uuid-004.zones	IN	PTR	newzone.example.com.
@@ -675,7 +675,7 @@ $ORIGIN catalog1.example.com.
 @	IN	SOA	ns1.example.com. admin.example.com. (
 		2024040101 3600 900 604800 0 )
 	IN	NS	invalid.
-version.catalog		IN	TXT	"2"
+version		IN	TXT	"2"
 uuid-002.zones	IN	PTR	beta.example.com.
 uuid-003.zones	IN	PTR	shared.example.com.
 group.uuid-002.zones	IN	TXT	"should-be-ignored"

--- a/test/catalog1.example.com.zone
+++ b/test/catalog1.example.com.zone
@@ -15,7 +15,7 @@ $ORIGIN catalog1.example.com.
 ;
 ; Catalog zone version (RFC 9432 §4.2)
 ;
-version.catalog		IN	TXT	"2"
+version		IN	TXT	"2"
 ;
 ; Member zones (PTR records under *.zones.catalog)
 ;

--- a/test/catalog2.example.com.zone
+++ b/test/catalog2.example.com.zone
@@ -15,7 +15,7 @@ $ORIGIN catalog2.example.com.
 ;
 ; Catalog zone version (RFC 9432 §4.2)
 ;
-version.catalog		IN	TXT	"2"
+version		IN	TXT	"2"
 ;
 ; Member zones (PTR records under *.zones.catalog)
 ;


### PR DESCRIPTION
## Summary

Fixes the owner name of the catalog zone version record so it conforms to [RFC 9432](https://www.rfc-editor.org/rfc/rfc9432).

## Problem

When generating a catalog zone (e.g. `catalog.cesnet.cz`), the version record was emitted as the relative name `version.catalog`. Because the zone file also contains `$ORIGIN catalog.cesnet.cz.`, BIND expanded this to:

```text
version.catalog.catalog.cesnet.cz. 86400 IN TXT "2"
```

The `catalog` label was duplicated. Per RFC 9432 the correct owner name is:

```text
version.catalog.cesnet.cz. 86400 IN TXT "2"
```

## Fix

- Changed the generator in `sauron` to emit the relative name `version` instead of `version.catalog`. With the existing `$ORIGIN` directive this expands to the correct FQDN.
- Updated `import-catalog-zone` to detect the canonical `version.<origin>` form instead of the old `version.catalog.<origin>` form.
- Updated test fixtures (`test/catalog1.example.com.zone`, `test/catalog2.example.com.zone`) and the integration test (`t/13-catalog-aggregate.t`) to use the canonical form.

## Files changed

- `sauron`
- `import-catalog-zone`
- `test/catalog1.example.com.zone`
- `test/catalog2.example.com.zone`
- `t/13-catalog-aggregate.t`

## Testing

- Verified Perl syntax of modified scripts with `perl -c`.
- Updated `t/13-catalog-aggregate.t` to check the generated version record in its relative form (`version`) as it appears in the zone file.